### PR TITLE
anytree dependency

### DIFF
--- a/xtree/tests/test_datatree.py
+++ b/xtree/tests/test_datatree.py
@@ -91,8 +91,35 @@ class TestTreeNodes:
         assert mary.parent is john
         assert kate.parent is john
 
-    def test_no_identical_twins(self):
-        ...
+    def test_disown_child(self):
+        john = TreeNode("john")
+        mary = TreeNode("mary", parent=john)
+        mary.parent = None
+        assert mary not in john.children
+
+    def test_add_child(self):
+        john = TreeNode("john")
+        kate = TreeNode("kate")
+        john.add_child(kate)
+        assert kate in john.children
+        assert kate.parent is john
+        with pytest.raises(KeyError, match="already has a child named"):
+            john.add_child(TreeNode("kate"))
+
+    def test_assign_children(self):
+        john = TreeNode("john")
+        jack = TreeNode("jack")
+        jill = TreeNode("jill")
+
+        john.children = (jack, jill)
+        assert jack in john.children
+        assert jack.parent is john
+        assert jill in john.children
+        assert jill.parent is john
+
+        evil_twin_jill = TreeNode("jill")
+        with pytest.raises(KeyError, match="already has a child named"):
+            john.children = (jack, jill, evil_twin_jill)
 
     def test_sibling_relationships(self):
         mary = TreeNode("mary")
@@ -118,10 +145,21 @@ class TestTreeNodes:
         raise NotImplementedError
 
 
-class TestTreePlanting:
+class TestTreeCreation:
     def test_empty(self):
         dt = DataTree()
-        root = DataTree()
+        assert dt.name == "root"
+        assert dt.parent is None
+        assert dt.children is ()
+        assert dt.ds is None
+
+    def test_data_in_root(self):
+        dt = DataTree({"root": xr.Dataset()})
+        print(dt.name)
+        assert dt.name == "root"
+        assert dt.parent is None
+        assert dt.children is ()
+        assert dt.ds is xr.Dataset()
 
     def test_one_layer(self):
         dt = DataTree({"run1": xr.Dataset(), "run2": xr.DataArray()})
@@ -147,11 +185,18 @@ class TestRestructuring:
 
 
 class TestRepr:
-    ...
+    def test_render_nodetree(self):
+        mary = TreeNode("mary")
+        kate = TreeNode("kate")
+        john = TreeNode("john", children=[mary, kate])
+        sam = TreeNode("Sam", parent=mary)
+        ben = TreeNode("Ben", parent=mary)
+        john.render()
+        assert False
 
-
-class TestIO:
-    ...
+    def test_render_datatree(self):
+        dt = create_test_datatree()
+        dt.render()
 
 
 class TestMethodInheritance:
@@ -159,4 +204,8 @@ class TestMethodInheritance:
 
 
 class TestUFuncs:
+    ...
+
+
+class TestIO:
     ...


### PR DESCRIPTION
Rewrite so that tree node class inherits from the `NodeMixin` class from the [anytree library](https://github.com/c0fec0de/anytree).

This should be temporary, as the functionality from `anytree` can be re-implemented to avoid this dependency, but adding the library explicitly at this point helps avoid re-inventing the wheel.