### PR TITLE
Allow for older python and empty dataset with attributes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@v2

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - python>=3.9
+  - python>=3.7
   - xarray>=0.20.2
   - netcdf4
   - anytree

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.9
+  - python>=3.7
   - xarray>=0.20.2
   - netcdf4
   - anytree

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -123,7 +123,7 @@ class DataTree(
     @property
     def has_data(self) -> bool:
         return len(self.ds.variables) > 0
-    
+
     @property
     def has_attrs(self) -> bool:
         return len(self.ds.attrs.keys()) > 0

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -215,7 +215,7 @@ class DataTree(
             node_line = f"{pre}{node_repr.splitlines()[0]}"
             lines.append(node_line)
 
-            if node.has_data:
+            if isinstance(node.ds, Dataset):
                 ds_repr = node_repr.splitlines()[2:]
                 for line in ds_repr:
                     if len(node.children) > 0:
@@ -235,7 +235,7 @@ class DataTree(
         """Information about this node, not including its relationships to other nodes."""
         node_info = f"DataTree('{self.name}')"
 
-        if self.has_data:
+        if isinstance(self.ds, Dataset):
             ds_info = "\n" + repr(self.ds)
         else:
             ds_info = ""
@@ -247,8 +247,8 @@ class DataTree(
         parent = self.parent.name if self.parent is not None else "None"
         node_str = f"DataTree(name='{self.name}', parent='{parent}', children={[c.name for c in self.children]},"
 
-        if self.has_data:
-            ds_repr_lines = self.ds.__repr__().splitlines()
+        if isinstance(self.ds, Dataset):
+            ds_repr_lines = repr(self.ds).splitlines()
             ds_repr = (
                 ds_repr_lines[0]
                 + "\n"

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -123,6 +123,10 @@ class DataTree(
     @property
     def has_data(self) -> bool:
         return len(self.ds.variables) > 0
+    
+    @property
+    def has_attrs(self) -> bool:
+        return len(self.ds.attrs.keys()) > 0
 
     @classmethod
     def from_dict(
@@ -215,7 +219,7 @@ class DataTree(
             node_line = f"{pre}{node_repr.splitlines()[0]}"
             lines.append(node_line)
 
-            if isinstance(node.ds, Dataset):
+            if node.has_data or node.has_attrs:
                 ds_repr = node_repr.splitlines()[2:]
                 for line in ds_repr:
                     if len(node.children) > 0:
@@ -235,7 +239,7 @@ class DataTree(
         """Information about this node, not including its relationships to other nodes."""
         node_info = f"DataTree('{self.name}')"
 
-        if isinstance(self.ds, Dataset):
+        if self.has_data or self.has_attrs:
             ds_info = "\n" + repr(self.ds)
         else:
             ds_info = ""
@@ -247,7 +251,7 @@ class DataTree(
         parent = self.parent.name if self.parent is not None else "None"
         node_str = f"DataTree(name='{self.name}', parent='{parent}', children={[c.name for c in self.children]},"
 
-        if isinstance(self.ds, Dataset):
+        if self.has_data or self.has_attrs:
             ds_repr_lines = repr(self.ds).splitlines()
             ds_repr = (
                 ds_repr_lines[0]

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -9,6 +9,7 @@ from anytree.iterators import LevelOrderIter
 from xarray import DataArray, Dataset
 
 from .treenode import TreeNode
+from .utils import removeprefix, removesuffix
 
 if TYPE_CHECKING:
     from .datatree import DataTree
@@ -215,7 +216,7 @@ def map_over_subtree(func: Callable) -> DataTree | Tuple[DataTree, ...]:
         # Find out how many return values we received
         num_return_values = _check_all_return_values(out_data_objects)
 
-        ancestors_of_new_root = first_tree.pathstr.removesuffix(first_tree.name)
+        ancestors_of_new_root = removesuffix(first_tree.pathstr, first_tree.name)
 
         # Reconstruct 1+ subtrees from the dict of results, by filling in all nodes of all result trees
         result_trees = []
@@ -233,7 +234,7 @@ def map_over_subtree(func: Callable) -> DataTree | Tuple[DataTree, ...]:
 
                 # Discard parentage so that new trees don't include parents of input nodes
                 # TODO use a proper relative_path method on DataTree(/TreeNode) to do this
-                relative_path = p.removeprefix(ancestors_of_new_root)
+                relative_path = removeprefix(p, ancestors_of_new_root)
                 out_tree_contents[relative_path] = output_node_data
 
             new_tree = DataTree.from_dict(

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -1,4 +1,5 @@
 import pytest
+import textwrap
 import xarray as xr
 import xarray.testing as xrt
 from anytree.resolver import ChildResolverError
@@ -292,6 +293,18 @@ class TestRepr:
         dt = DataTree("root")
         printout = dt.__str__()
         assert printout == "DataTree('root', parent=None)"
+    
+    def test_print_empty_node_with_attrs(self):
+        dat = xr.Dataset(attrs={'note':'has attrs'})
+        dt = DataTree("root", data=dat)
+        printout = dt.__str__()
+        assert printout == textwrap.dedent("""\
+            DataTree('root', parent=None)
+            Dimensions:  ()
+            Data variables:
+                *empty*
+            Attributes:
+                note:     has attrs""")
 
     def test_print_node_with_data(self):
         dat = xr.Dataset({"a": [0, 2]})

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -1,5 +1,6 @@
-import pytest
 import textwrap
+
+import pytest
 import xarray as xr
 import xarray.testing as xrt
 from anytree.resolver import ChildResolverError
@@ -293,9 +294,9 @@ class TestRepr:
         dt = DataTree("root")
         printout = dt.__str__()
         assert printout == "DataTree('root', parent=None)"
-    
+
     def test_print_empty_node_with_attrs(self):
-        dat = xr.Dataset(attrs={'note':'has attrs'})
+        dat = xr.Dataset(attrs={'note': 'has attrs'})
         dt = DataTree("root", data=dat)
         printout = dt.__str__()
         assert printout == textwrap.dedent("""\

--- a/datatree/tests/test_utils.py
+++ b/datatree/tests/test_utils.py
@@ -1,0 +1,48 @@
+import pytest
+
+from datatree.utils import removesuffix, removeprefix
+
+def checkequal(expected_result, obj, method, *args, **kwargs):
+    result = method(obj, *args, **kwargs)
+    assert result == expected_result
+
+def checkraises(exc, obj, method, *args):
+    try:
+        result = method(obj, *args)
+    except Exception as e:
+        assert isinstance(e, exc) is True
+
+def test_removeprefix():
+    checkequal('am', 'spam', removeprefix, 'sp')
+    checkequal('spamspam', 'spamspamspam', removeprefix, 'spam')
+    checkequal('spam', 'spam', removeprefix, 'python')
+    checkequal('spam', 'spam', removeprefix, 'spider')
+    checkequal('spam', 'spam', removeprefix, 'spam and eggs')
+    checkequal('', '', removeprefix, '')
+    checkequal('', '', removeprefix, 'abcde')
+    checkequal('abcde', 'abcde', removeprefix, '')
+    checkequal('', 'abcde', removeprefix, 'abcde')
+
+    checkraises(TypeError, 'hello', removeprefix)
+    checkraises(TypeError, 'hello', removeprefix, 42)
+    checkraises(TypeError, 'hello', removeprefix, 42, 'h')
+    checkraises(TypeError, 'hello', removeprefix, 'h', 42)
+    checkraises(TypeError, 'hello', removeprefix, ("he", "l"))
+
+def test_removesuffix():
+    checkequal('sp', 'spam', removesuffix, 'am')
+    checkequal('spamspam', 'spamspamspam', removesuffix, 'spam')
+    checkequal('spam', 'spam', removesuffix, 'python')
+    checkequal('spam', 'spam', removesuffix, 'blam')
+    checkequal('spam', 'spam', removesuffix, 'eggs and spam')
+
+    checkequal('', '', removesuffix, '')
+    checkequal('', '', removesuffix, 'abcde')
+    checkequal('abcde', 'abcde', removesuffix, '')
+    checkequal('', 'abcde', removesuffix, 'abcde')
+
+    checkraises(TypeError, 'hello', removesuffix)
+    checkraises(TypeError, 'hello', removesuffix, 42)
+    checkraises(TypeError, 'hello', removesuffix, 42, 'h')
+    checkraises(TypeError, 'hello', removesuffix, 'h', 42)
+    checkraises(TypeError, 'hello', removesuffix, ("lo", "l"))

--- a/datatree/tests/test_utils.py
+++ b/datatree/tests/test_utils.py
@@ -1,16 +1,17 @@
-import pytest
+from datatree.utils import removeprefix, removesuffix
 
-from datatree.utils import removesuffix, removeprefix
 
 def checkequal(expected_result, obj, method, *args, **kwargs):
     result = method(obj, *args, **kwargs)
     assert result == expected_result
 
+
 def checkraises(exc, obj, method, *args):
     try:
-        result = method(obj, *args)
+        method(obj, *args)
     except Exception as e:
         assert isinstance(e, exc) is True
+
 
 def test_removeprefix():
     checkequal('am', 'spam', removeprefix, 'sp')
@@ -28,6 +29,7 @@ def test_removeprefix():
     checkraises(TypeError, 'hello', removeprefix, 42, 'h')
     checkraises(TypeError, 'hello', removeprefix, 'h', 42)
     checkraises(TypeError, 'hello', removeprefix, ("he", "l"))
+
 
 def test_removesuffix():
     checkequal('sp', 'spam', removesuffix, 'am')

--- a/datatree/utils.py
+++ b/datatree/utils.py
@@ -9,7 +9,7 @@ def removesuffix(base: str, suffix: str) -> str:
         return base
 
 def removeprefix(base: str, prefix: str) -> str:
-    if sys.version_info < (3, 9):
+    if sys.version_info >= (3, 9):
         return base.removeprefix(prefix)
     else:
         if base.startswith(prefix):

--- a/datatree/utils.py
+++ b/datatree/utils.py
@@ -1,5 +1,6 @@
 import sys
 
+
 def removesuffix(base: str, suffix: str) -> str:
     if sys.version_info >= (3, 9):
         return base.removesuffix(suffix)
@@ -7,6 +8,7 @@ def removesuffix(base: str, suffix: str) -> str:
         if base.endswith(suffix):
             return base[:len(base) - len(suffix)]
         return base
+
 
 def removeprefix(base: str, prefix: str) -> str:
     if sys.version_info >= (3, 9):

--- a/datatree/utils.py
+++ b/datatree/utils.py
@@ -1,0 +1,17 @@
+import sys
+
+def removesuffix(base: str, suffix: str) -> str:
+    if sys.version_info >= (3, 9):
+        return base.removesuffix(suffix)
+    else:
+        if base.endswith(suffix):
+            return base[:len(base) - len(suffix)]
+        return base
+
+def removeprefix(base: str, prefix: str) -> str:
+    if sys.version_info < (3, 9):
+        return base.removeprefix(prefix)
+    else:
+        if base.startswith(prefix):
+            return base[len(prefix):]
+        return base

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     packages=find_packages(exclude=["docs", "tests", "tests.*", "docs.*"]),
     install_requires=install_requires,
-    python_requires=">=3.9",
+    python_requires=">=3.7",
     setup_requires="setuptools_scm",
     use_scm_version={
         "write_to": "datatree/_version.py",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         "License :: OSI Approved :: Apache License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8"
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],


### PR DESCRIPTION
## Overview
This PR updates the repr so that DataTree still shows the xarray dataset when there are **no data**, but there are important **attributes**. Additionally, `utils.py` has been added for the `removeprefix` and `removesuffix` method to enable their use for python 3.9 and older. Now the package should require a minimum of python 3.7.

## Checklist
- [X] Tests added
- [X] Passes `pre-commit run --all-files`
- [X] New functions/methods are listed in `api.rst`
