### PR TITLE
Update installation instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -2,14 +2,29 @@
 Installation
 ============
 
-Datatree is not yet available on pypi or via conda, so for now you will have to install it from source.
+Datatree can be installed in three ways:
 
-``git clone https://github.com/TomNicholas/datatree.git```
+Using the `conda <https://conda.io/>`__ package manager that comes with the
+Anaconda/Miniconda distribution:
 
-``pip install -e ./datatree/``
+.. code:: bash
 
-The main branch will be kept up-to-date, so if you clone main and run the test suite with ``pytest datatree`` and get no failures,
-then you have the most up-to-date version.
+    $ conda install xarray-datatree --channel conda-forge
+
+Using the `pip <https://pypi.org/project/pip/>`__ package manager:
+
+.. code:: bash
+
+    $ python -m pip install xarray-datatree
+
+To install a development version from source:
+
+.. code:: bash
+
+    $ git clone https://github.com/xarray-contrib/datatree
+    $ cd datatree
+    $ python -m pip install -e . 
+
 
 You will need xarray and `anytree <https://github.com/c0fec0de/anytree>`_
 as dependencies, with netcdf4, zarr, and h5netcdf as optional dependencies to allow file I/O.
@@ -19,4 +34,4 @@ as dependencies, with netcdf4, zarr, and h5netcdf as optional dependencies to al
     Datatree is very much still in the early stages of development. There may be functions that are present but whose
     internals are not yet implemented, or significant changes to the API in future.
     That said, if you try it out and find some behaviour that looks like a bug to you, please report it on the
-    `issue tracker <https://github.com/TomNicholas/datatree/issues>`_!
+    `issue tracker <https://github.com/xarray-contrib/datatree/issues>`_!

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,7 +23,7 @@ To install a development version from source:
 
     $ git clone https://github.com/xarray-contrib/datatree
     $ cd datatree
-    $ python -m pip install -e . 
+    $ python -m pip install -e .
 
 
 You will need xarray and `anytree <https://github.com/c0fec0de/anytree>`_


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I submitted a recipe to conda-forge, and now `xarray-datatree` can be installed from conda. This PR updates the docs to reflect this change. 

