### PR TITLE
to/from_dict

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Generic,
     Iterable,
     Mapping,
@@ -306,7 +307,7 @@ class DataTree(
     @classmethod
     def from_dict(
         cls,
-        d: MutableMapping[str, DataTree | Dataset | DataArray],
+        d: MutableMapping[str, Dataset | DataArray | None],
         name: str = None,
     ) -> DataTree:
         """
@@ -327,19 +328,22 @@ class DataTree(
         Returns
         -------
         DataTree
+
+        Notes
+        -----
+        If your dictionary is nested you will need to flatten it before using this method.
         """
 
         # First create the root node
-        # TODO there is a real bug here where what if root_data is of type DataTree?
         root_data = d.pop("/", None)
-        obj = cls(name=name, data=root_data, parent=None, children=None)  # type: ignore[arg-type]
+        obj = cls(name=name, data=root_data, parent=None, children=None)
 
         if d:
             # Populate tree with children determined from data_objects mapping
             for path, data in d.items():
                 # Create and set new node
                 node_name = NodePath(path).name
-                new_node = cls(name=node_name, data=data)  # type: ignore[arg-type]
+                new_node = cls(name=node_name, data=data)
                 obj._set_item(
                     path,
                     new_node,
@@ -347,6 +351,16 @@ class DataTree(
                     new_nodes_along_path=True,
                 )
         return obj
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Create a dictionary mapping of absolute node paths to the data contained in those nodes.
+
+        Returns
+        -------
+        Dict
+        """
+        return {node.path: node.ds for node in self.subtree}
 
     @property
     def nbytes(self) -> int:

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -330,6 +330,11 @@ class TestTreeFromDict:
             "/set3",
         ]
 
+    def test_roundtrip(self):
+        dt = create_test_datatree()
+        roundtrip = DataTree.from_dict(dt.to_dict())
+        assert roundtrip.equals(dt)
+
 
 class TestBrowsing:
     ...

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -335,6 +335,15 @@ class TestTreeFromDict:
         roundtrip = DataTree.from_dict(dt.to_dict())
         assert roundtrip.equals(dt)
 
+    @pytest.mark.xfail
+    def test_roundtrip_unnamed_root(self):
+        # See GH81
+
+        dt = create_test_datatree()
+        dt.name = "root"
+        roundtrip = DataTree.from_dict(dt.to_dict())
+        assert roundtrip.equals(dt)
+
 
 class TestBrowsing:
     ...

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -215,13 +215,13 @@ I/O
 
    open_datatree
    DataTree.from_dict
+   DataTree.to_dict
    DataTree.to_netcdf
    DataTree.to_zarr
 
 ..
 
    Missing
-   DataTree.to_dict
    open_mfdatatree
 
 Exceptions

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -38,6 +38,8 @@ New Features
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - New delitem method so you can delete nodes. (:pull:`88`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- New ``to_dict`` method. (:pull:`82`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Adds a simple `.to_dict()` method, and documents the behaviour in #81 in the tests. Also fixes some typing errors.

- [x] Closes #xxxx
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] New functions/methods are listed in `api.rst`
