### PR TITLE
Str repr indentation

### DIFF
--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -69,7 +69,7 @@ def tree_repr(dt):
                 if len(node.children) > 0:
                     lines.append(f"{fill}{renderer.style.vertical}{line}")
                 else:
-                    lines.append(f"{fill}{line}")
+                    lines.append(f"{fill}{' ' * len(renderer.style.vertical)}{line}")
 
     # Tack on info about whether or not root node has a parent at the start
     first_line = lines[0]

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -1,5 +1,3 @@
-import textwrap
-
 import pytest
 import xarray as xr
 import xarray.testing as xrt
@@ -337,57 +335,3 @@ class TestBrowsing:
 
 class TestRestructuring:
     ...
-
-
-class TestRepr:
-    def test_print_empty_node(self):
-        dt = DataTree(name="root")
-        printout = dt.__str__()
-        assert printout == "DataTree('root', parent=None)"
-
-    def test_print_empty_node_with_attrs(self):
-        dat = xr.Dataset(attrs={"note": "has attrs"})
-        dt = DataTree(name="root", data=dat)
-        printout = dt.__str__()
-        assert printout == textwrap.dedent(
-            """\
-            DataTree('root', parent=None)
-            Dimensions:  ()
-            Data variables:
-                *empty*
-            Attributes:
-                note:     has attrs"""
-        )
-
-    def test_print_node_with_data(self):
-        dat = xr.Dataset({"a": [0, 2]})
-        dt = DataTree(name="root", data=dat)
-        printout = dt.__str__()
-        expected = [
-            "DataTree('root', parent=None)",
-            "Dimensions",
-            "Coordinates",
-            "a",
-            "Data variables",
-            "*empty*",
-        ]
-        for expected_line, printed_line in zip(expected, printout.splitlines()):
-            assert expected_line in printed_line
-
-    def test_nested_node(self):
-        dat = xr.Dataset({"a": [0, 2]})
-        root = DataTree(name="root")
-        DataTree(name="results", data=dat, parent=root)
-        printout = root.__str__()
-        assert printout.splitlines()[2].startswith("    ")
-
-    def test_print_datatree(self):
-        dt = create_test_datatree()
-        print(dt)
-
-        # TODO work out how to test something complex like this
-
-    def test_repr_of_node_with_data(self):
-        dat = xr.Dataset({"a": [0, 2]})
-        dt = DataTree(name="root", data=dat)
-        assert "Coordinates" in repr(dt)

--- a/datatree/tests/test_formatting.py
+++ b/datatree/tests/test_formatting.py
@@ -5,6 +5,62 @@ from xarray import Dataset
 from datatree import DataTree
 from datatree.formatting import diff_tree_repr
 
+from .test_datatree import create_test_datatree
+
+
+class TestRepr:
+    def test_print_empty_node(self):
+        dt = DataTree(name="root")
+        printout = dt.__str__()
+        assert printout == "DataTree('root', parent=None)"
+
+    def test_print_empty_node_with_attrs(self):
+        dat = Dataset(attrs={"note": "has attrs"})
+        dt = DataTree(name="root", data=dat)
+        printout = dt.__str__()
+        assert printout == dedent(
+            """\
+            DataTree('root', parent=None)
+                Dimensions:  ()
+                Data variables:
+                    *empty*
+                Attributes:
+                    note:     has attrs"""
+        )
+
+    def test_print_node_with_data(self):
+        dat = Dataset({"a": [0, 2]})
+        dt = DataTree(name="root", data=dat)
+        printout = dt.__str__()
+        expected = [
+            "DataTree('root', parent=None)",
+            "Dimensions",
+            "Coordinates",
+            "a",
+            "Data variables",
+            "*empty*",
+        ]
+        for expected_line, printed_line in zip(expected, printout.splitlines()):
+            assert expected_line in printed_line
+
+    def test_nested_node(self):
+        dat = Dataset({"a": [0, 2]})
+        root = DataTree(name="root")
+        DataTree(name="results", data=dat, parent=root)
+        printout = root.__str__()
+        assert printout.splitlines()[2].startswith("    ")
+
+    def test_print_datatree(self):
+        dt = create_test_datatree()
+        print(dt)
+
+        # TODO work out how to test something complex like this
+
+    def test_repr_of_node_with_data(self):
+        dat = Dataset({"a": [0, 2]})
+        dt = DataTree(name="root", data=dat)
+        assert "Coordinates" in repr(dt)
+
 
 class TestDiffFormatting:
     def test_diff_structure(self):

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -60,6 +60,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Fixed indentation issue with the string repr (:pull:`86`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
- [x] Fixes a lack of indenting in the string reprs, so that this

```python
In [1]: import xarray as xr

In [2]: import numpy as np

In [3]: from datatree import DataTree

In [4]: simpsons = DataTree.from_dict(
   ...:     {"/": xr.Dataset({"Age": np.NaN}),
   ...:      "Homer": xr.Dataset({"Age": 39}),
   ...:      "Homer/Bart": xr.Dataset({"Age": 10}),
   ...:      "Homer/Lisa": xr.Dataset({"Age": 8}),
   ...:      "Homer/Maggie": xr.Dataset({"Age": 1})},
   ...:      name="Abe",
   ...: )
```
displays as this
```
DataTree('Abe', parent=None)
│   Dimensions:  ()
│   Data variables:
│       Age      float64 nan
└── DataTree('Homer')
    │   Dimensions:  ()
    │   Data variables:
    │       Age      int64 39
    ├── DataTree('Bart')
    │       Dimensions:  ()
    │       Data variables:
    │           Age      int64 10
    ├── DataTree('Lisa')
    │       Dimensions:  ()
    │       Data variables:
    │           Age      int64 8
    └── DataTree('Maggie')
            Dimensions:  ()
            Data variables:
                Age      int64 1

```
instead of this
```
DataTree('Abe', parent=None)
│   Dimensions:  ()
│   Data variables:
│       Age      float64 nan
└── DataTree('Homer')
    │   Dimensions:  ()
    │   Data variables:
    │       Age      int64 39
    ├── DataTree('Bart')
    │   Dimensions:  ()
    │   Data variables:
    │       Age      int64 10
    ├── DataTree('Lisa')
    │   Dimensions:  ()
    │   Data variables:
    │       Age      int64 8
    └── DataTree('Maggie')
        Dimensions:  ()
        Data variables:
            Age      int64 1
```

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] New functions/methods are listed in `api.rst`
