### PR TITLE
compress DataTree when saving to NetCDF

### DIFF
--- a/datatree/io.py
+++ b/datatree/io.py
@@ -160,8 +160,8 @@ def _datatree_to_netcdf(
                 filepath,
                 group=group_path,
                 mode=mode,
-                encoding=_maybe_extract_group_kwargs(encoding, dt.path),
-                unlimited_dims=_maybe_extract_group_kwargs(unlimited_dims, dt.path),
+                encoding=_maybe_extract_group_kwargs(encoding, group_path),
+                unlimited_dims=_maybe_extract_group_kwargs(unlimited_dims, group_path),
                 **kwargs,
             )
         mode = "a"

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -18,6 +18,23 @@ class TestIO:
         roundtrip_dt = open_datatree(filepath)
         assert_equal(original_dt, roundtrip_dt)
 
+    @requires_netCDF4
+    def test_netcdf_compression(self, tmpdir):
+        filepath = str(
+            tmpdir / "test.nc"
+        )  # casting to str avoids a pathlib bug in xarray
+        original_dt = create_test_datatree()
+
+        # add compression
+        comp = dict(zlib=True, complevel=9)
+        enc = {"set1": {var: comp for var in original_dt["set1"].ds.data_vars}}
+
+        original_dt.to_netcdf(filepath, encoding=enc, engine="netcdf4")
+        roundtrip_dt = open_datatree(filepath)
+
+        assert roundtrip_dt["set1/a"].encoding["zlib"] == comp["zlib"]
+        assert roundtrip_dt["set1/a"].encoding["complevel"] == comp["complevel"]
+
     @requires_h5netcdf
     def test_to_h5netcdf(self, tmpdir):
         filepath = str(


### PR DESCRIPTION
@jhamman Attempt to fix #89.

Added test for compression `test_netcdf_compression` in `datatree/tests/test_io.py`. This test still fails.

