### PR TITLE
Remove anytree dependency from CI runs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,8 +75,7 @@ jobs:
         run: |
           python -m pip install --no-deps --upgrade \
             git+https://github.com/pydata/xarray \
-            git+https://github.com/Unidata/netcdf4-python \
-            git+https://github.com/c0fec0de/anytree
+            git+https://github.com/Unidata/netcdf4-python
           python -m pip install --no-deps -e .
           python -m pip list
       - name: Running Tests

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -26,8 +26,7 @@ To install a development version from source:
     $ python -m pip install -e .
 
 
-You will need xarray and `anytree <https://github.com/c0fec0de/anytree>`_
-as dependencies, with netcdf4, zarr, and h5netcdf as optional dependencies to allow file I/O.
+You will just need xarray as a required dependency, with netcdf4, zarr, and h5netcdf as optional dependencies to allow file I/O.
 
 .. note::
 


### PR DESCRIPTION
This should have been done in #76 but I missed it.
