### PR TITLE
Name checking

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -87,7 +87,7 @@ class DataTree(
 
     def __init__(
         self,
-        data: Optional[Dataset | DataArray] = None,
+        data: Dataset | DataArray = None,
         parent: DataTree = None,
         children: Mapping[str, DataTree] = None,
         name: str = None,
@@ -119,7 +119,7 @@ class DataTree(
         super().__init__(children=children)
         self.name = name
         self.parent = parent
-        self.ds = data  # type: ignore[assignment]
+        self.ds = data
 
     @property
     def name(self) -> str | None:

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -128,6 +128,11 @@ class DataTree(
 
     @name.setter
     def name(self, name: str | None) -> None:
+        if name is not None:
+            if not isinstance(name, str):
+                raise TypeError("node name must be a string or None")
+            if "/" in name:
+                raise ValueError("node names cannot contain forward slashes")
         self._name = name
 
     @property

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -63,6 +63,13 @@ class TestTreeCreation:
         dt = DataTree()
         assert dt.name is None
 
+    def test_bad_names(self):
+        with pytest.raises(TypeError):
+            DataTree(name=5)
+
+        with pytest.raises(ValueError):
+            DataTree(name="folder/data")
+
 
 class TestFamilyTree:
     def test_setparent_unnamed_child_node_fails(self):

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -38,6 +38,8 @@ Bug fixes
   By `Matt McCormick <https://github.com/thewtex>`_.
 - Fix netCDF encoding for compression (:pull:`95`)
   By `Joe Hamman <https://github.com/jhamman>`_.
+- Added validity checking for node names (:pull:`106`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Adds a small check to prevent users from creating a node with a name that contains "/", which would mess up path-like access.

- [ ] Closes #xxxx
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] New functions/methods are listed in `api.rst`
- [x] Changes are summarized in `docs/source/whats-new.rst`
