### PR TITLE
Make create_test_datatree a pytest.fixture

### DIFF
--- a/datatree/tests/conftest.py
+++ b/datatree/tests/conftest.py
@@ -1,7 +1,8 @@
 import pytest
-
 import xarray as xr
+
 from datatree import DataTree
+
 
 @pytest.fixture(scope="module")
 def create_test_datatree():
@@ -34,6 +35,7 @@ def create_test_datatree():
     The structure has deliberately repeated names of tags, variables, and
     dimensions in order to better check for bugs caused by name conflicts.
     """
+
     def _create_test_datatree(modify=lambda ds: ds):
         set1_data = modify(xr.Dataset({"a": 0, "b": 1}))
         set2_data = modify(xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])}))
@@ -49,7 +51,9 @@ def create_test_datatree():
         DataTree(name="set3", parent=root)
 
         return root
+
     return _create_test_datatree
+
 
 @pytest.fixture(scope="module")
 def simple_datatree(create_test_datatree):

--- a/datatree/tests/conftest.py
+++ b/datatree/tests/conftest.py
@@ -1,0 +1,61 @@
+import pytest
+
+import xarray as xr
+from datatree import DataTree
+
+@pytest.fixture(scope="module")
+def create_test_datatree():
+    """
+    Create a test datatree with this structure:
+
+    <datatree.DataTree>
+    |-- set1
+    |   |-- <xarray.Dataset>
+    |   |   Dimensions:  ()
+    |   |   Data variables:
+    |   |       a        int64 0
+    |   |       b        int64 1
+    |   |-- set1
+    |   |-- set2
+    |-- set2
+    |   |-- <xarray.Dataset>
+    |   |   Dimensions:  (x: 2)
+    |   |   Data variables:
+    |   |       a        (x) int64 2, 3
+    |   |       b        (x) int64 0.1, 0.2
+    |   |-- set1
+    |-- set3
+    |-- <xarray.Dataset>
+    |   Dimensions:  (x: 2, y: 3)
+    |   Data variables:
+    |       a        (y) int64 6, 7, 8
+    |       set0     (x) int64 9, 10
+
+    The structure has deliberately repeated names of tags, variables, and
+    dimensions in order to better check for bugs caused by name conflicts.
+    """
+    def _create_test_datatree(modify=lambda ds: ds):
+        set1_data = modify(xr.Dataset({"a": 0, "b": 1}))
+        set2_data = modify(xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])}))
+        root_data = modify(xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])}))
+
+        # Avoid using __init__ so we can independently test it
+        root = DataTree(data=root_data)
+        set1 = DataTree(name="set1", parent=root, data=set1_data)
+        DataTree(name="set1", parent=set1)
+        DataTree(name="set2", parent=set1)
+        set2 = DataTree(name="set2", parent=root, data=set2_data)
+        DataTree(name="set1", parent=set2)
+        DataTree(name="set3", parent=root)
+
+        return root
+    return _create_test_datatree
+
+@pytest.fixture(scope="module")
+def simple_datatree(create_test_datatree):
+    """
+    Invoke create_test_datatree fixture (callback).
+
+    Returns a DataTree.
+    """
+    return create_test_datatree()

--- a/datatree/tests/test_dataset_api.py
+++ b/datatree/tests/test_dataset_api.py
@@ -93,7 +93,7 @@ class TestOps:
 
 
 class TestUFuncs:
-    def test_tree(self):
+    def test_tree(self, create_test_datatree):
         dt = create_test_datatree()
         expected = create_test_datatree(modify=lambda ds: np.sin(ds))
         result_tree = np.sin(dt)

--- a/datatree/tests/test_dataset_api.py
+++ b/datatree/tests/test_dataset_api.py
@@ -4,8 +4,6 @@ import xarray as xr
 from datatree import DataTree
 from datatree.testing import assert_equal
 
-from .test_datatree import create_test_datatree
-
 
 class TestDSMethodInheritance:
     def test_dataset_method(self):

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -4,63 +4,6 @@ import xarray.testing as xrt
 
 from datatree import DataTree
 
-@pytest.fixture(scope="module")
-def create_test_datatree():
-    """
-    Create a test datatree with this structure:
-
-    <datatree.DataTree>
-    |-- set1
-    |   |-- <xarray.Dataset>
-    |   |   Dimensions:  ()
-    |   |   Data variables:
-    |   |       a        int64 0
-    |   |       b        int64 1
-    |   |-- set1
-    |   |-- set2
-    |-- set2
-    |   |-- <xarray.Dataset>
-    |   |   Dimensions:  (x: 2)
-    |   |   Data variables:
-    |   |       a        (x) int64 2, 3
-    |   |       b        (x) int64 0.1, 0.2
-    |   |-- set1
-    |-- set3
-    |-- <xarray.Dataset>
-    |   Dimensions:  (x: 2, y: 3)
-    |   Data variables:
-    |       a        (y) int64 6, 7, 8
-    |       set0     (x) int64 9, 10
-
-    The structure has deliberately repeated names of tags, variables, and
-    dimensions in order to better check for bugs caused by name conflicts.
-    """
-    def _create_test_datatree(modify=lambda ds: ds):
-        set1_data = modify(xr.Dataset({"a": 0, "b": 1}))
-        set2_data = modify(xr.Dataset({"a": ("x", [2, 3]), "b": ("x", [0.1, 0.2])}))
-        root_data = modify(xr.Dataset({"a": ("y", [6, 7, 8]), "set0": ("x", [9, 10])}))
-
-        # Avoid using __init__ so we can independently test it
-        root = DataTree(data=root_data)
-        set1 = DataTree(name="set1", parent=root, data=set1_data)
-        DataTree(name="set1", parent=set1)
-        DataTree(name="set2", parent=set1)
-        set2 = DataTree(name="set2", parent=root, data=set2_data)
-        DataTree(name="set1", parent=set2)
-        DataTree(name="set3", parent=root)
-
-        return root
-    return _create_test_datatree
-
-@pytest.fixture(scope="module")
-def simple_datatree(create_test_datatree):
-    """
-    Invoke create_test_datatree fixture (callback).
-
-    Returns a DataTree.
-    """
-    return create_test_datatree()
-
 class TestTreeCreation:
     def test_empty(self):
         dt = DataTree(name="root")

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -4,6 +4,7 @@ import xarray.testing as xrt
 
 from datatree import DataTree
 
+
 class TestTreeCreation:
     def test_empty(self):
         dt = DataTree(name="root")

--- a/datatree/tests/test_formatting.py
+++ b/datatree/tests/test_formatting.py
@@ -5,8 +5,6 @@ from xarray import Dataset
 from datatree import DataTree
 from datatree.formatting import diff_tree_repr
 
-from .test_datatree import create_test_datatree, simple_datatree
-
 
 class TestRepr:
     def test_print_empty_node(self):

--- a/datatree/tests/test_formatting.py
+++ b/datatree/tests/test_formatting.py
@@ -5,7 +5,7 @@ from xarray import Dataset
 from datatree import DataTree
 from datatree.formatting import diff_tree_repr
 
-from .test_datatree import create_test_datatree
+from .test_datatree import create_test_datatree, simple_datatree
 
 
 class TestRepr:
@@ -50,8 +50,8 @@ class TestRepr:
         printout = root.__str__()
         assert printout.splitlines()[2].startswith("    ")
 
-    def test_print_datatree(self):
-        dt = create_test_datatree()
+    def test_print_datatree(self, simple_datatree):
+        dt = simple_datatree
         print(dt)
 
         # TODO work out how to test something complex like this

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -3,7 +3,6 @@ import pytest
 from datatree.io import open_datatree
 from datatree.testing import assert_equal
 from datatree.tests import requires_h5netcdf, requires_netCDF4, requires_zarr
-from datatree.tests.test_datatree import create_test_datatree, simple_datatree
 
 
 class TestIO:

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -3,27 +3,27 @@ import pytest
 from datatree.io import open_datatree
 from datatree.testing import assert_equal
 from datatree.tests import requires_h5netcdf, requires_netCDF4, requires_zarr
-from datatree.tests.test_datatree import create_test_datatree
+from datatree.tests.test_datatree import create_test_datatree, simple_datatree
 
 
 class TestIO:
     @requires_netCDF4
-    def test_to_netcdf(self, tmpdir):
+    def test_to_netcdf(self, tmpdir, simple_datatree):
         filepath = str(
             tmpdir / "test.nc"
         )  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
         original_dt.to_netcdf(filepath, engine="netcdf4")
 
         roundtrip_dt = open_datatree(filepath)
         assert_equal(original_dt, roundtrip_dt)
 
     @requires_netCDF4
-    def test_netcdf_encoding(self, tmpdir):
+    def test_netcdf_encoding(self, tmpdir, simple_datatree):
         filepath = str(
             tmpdir / "test.nc"
         )  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
 
         # add compression
         comp = dict(zlib=True, complevel=9)
@@ -40,35 +40,35 @@ class TestIO:
             original_dt.to_netcdf(filepath, encoding=enc, engine="netcdf4")
 
     @requires_h5netcdf
-    def test_to_h5netcdf(self, tmpdir):
+    def test_to_h5netcdf(self, tmpdir, simple_datatree):
         filepath = str(
             tmpdir / "test.nc"
         )  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
         original_dt.to_netcdf(filepath, engine="h5netcdf")
 
         roundtrip_dt = open_datatree(filepath)
         assert_equal(original_dt, roundtrip_dt)
 
     @requires_zarr
-    def test_to_zarr(self, tmpdir):
+    def test_to_zarr(self, tmpdir, simple_datatree):
         filepath = str(
             tmpdir / "test.zarr"
         )  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
         original_dt.to_zarr(filepath)
 
         roundtrip_dt = open_datatree(filepath, engine="zarr")
         assert_equal(original_dt, roundtrip_dt)
 
     @requires_zarr
-    def test_zarr_encoding(self, tmpdir):
+    def test_zarr_encoding(self, tmpdir, simple_datatree):
         import zarr
 
         filepath = str(
             tmpdir / "test.zarr"
         )  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
 
         comp = {"compressor": zarr.Blosc(cname="zstd", clevel=3, shuffle=2)}
         enc = {"/set2": {var: comp for var in original_dt["/set2"].ds.data_vars}}
@@ -83,13 +83,13 @@ class TestIO:
             original_dt.to_zarr(filepath, encoding=enc, engine="zarr")
 
     @requires_zarr
-    def test_to_zarr_zip_store(self, tmpdir):
+    def test_to_zarr_zip_store(self, tmpdir, simple_datatree):
         from zarr.storage import ZipStore
 
         filepath = str(
             tmpdir / "test.zarr.zip"
         )  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
         store = ZipStore(filepath)
         original_dt.to_zarr(store)
 
@@ -97,12 +97,12 @@ class TestIO:
         assert_equal(original_dt, roundtrip_dt)
 
     @requires_zarr
-    def test_to_zarr_not_consolidated(self, tmpdir):
+    def test_to_zarr_not_consolidated(self, tmpdir, simple_datatree):
         filepath = tmpdir / "test.zarr"
         zmetadata = filepath / ".zmetadata"
         s1zmetadata = filepath / "set1" / ".zmetadata"
         filepath = str(filepath)  # casting to str avoids a pathlib bug in xarray
-        original_dt = create_test_datatree()
+        original_dt = simple_datatree
         original_dt.to_zarr(filepath, consolidated=False)
         assert not zmetadata.exists()
         assert not s1zmetadata.exists()

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -5,7 +5,7 @@ from datatree.datatree import DataTree
 from datatree.mapping import TreeIsomorphismError, check_isomorphic, map_over_subtree
 from datatree.testing import assert_equal
 
-from .test_datatree import create_test_datatree
+from .test_datatree import create_test_datatree, simple_datatree
 
 empty = xr.Dataset()
 
@@ -60,14 +60,14 @@ class TestCheckTreesIsomorphic:
         dt2 = DataTree.from_dict({"A": empty, "B": empty, "B/C": empty, "B/D": empty})
         check_isomorphic(dt1, dt2)
 
-    def test_not_isomorphic_complex_tree(self):
+    def test_not_isomorphic_complex_tree(self, create_test_datatree):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
         dt2["set1/set2/extra"] = DataTree(name="extra")
         with pytest.raises(TreeIsomorphismError, match="/set1/set2"):
             check_isomorphic(dt1, dt2)
 
-    def test_checking_from_root(self):
+    def test_checking_from_root(self, create_test_datatree):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
         real_root = DataTree()
@@ -85,7 +85,7 @@ class TestMapOverSubTree:
         with pytest.raises(TypeError, match="Must pass at least one tree"):
             times_ten("dt")
 
-    def test_not_isomorphic(self):
+    def test_not_isomorphic(self, create_test_datatree):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
         dt2["set1/set2/extra"] = DataTree(name="extra")
@@ -97,7 +97,7 @@ class TestMapOverSubTree:
         with pytest.raises(TreeIsomorphismError):
             times_ten(dt1, dt2)
 
-    def test_no_trees_returned(self):
+    def test_no_trees_returned(self, create_test_datatree):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
 
@@ -108,7 +108,7 @@ class TestMapOverSubTree:
         with pytest.raises(TypeError, match="return value of None"):
             bad_func(dt1, dt2)
 
-    def test_single_dt_arg(self):
+    def test_single_dt_arg(self, create_test_datatree):
         dt = create_test_datatree()
 
         @map_over_subtree
@@ -119,7 +119,7 @@ class TestMapOverSubTree:
         result_tree = times_ten(dt)
         assert_equal(result_tree, expected)
 
-    def test_single_dt_arg_plus_args_and_kwargs(self):
+    def test_single_dt_arg_plus_args_and_kwargs(self, create_test_datatree):
         dt = create_test_datatree()
 
         @map_over_subtree
@@ -130,7 +130,7 @@ class TestMapOverSubTree:
         result_tree = multiply_then_add(dt, 10.0, add=2.0)
         assert_equal(result_tree, expected)
 
-    def test_multiple_dt_args(self):
+    def test_multiple_dt_args(self, create_test_datatree):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
 
@@ -142,7 +142,7 @@ class TestMapOverSubTree:
         result = add(dt1, dt2)
         assert_equal(result, expected)
 
-    def test_dt_as_kwarg(self):
+    def test_dt_as_kwarg(self, create_test_datatree):
         dt1 = create_test_datatree()
         dt2 = create_test_datatree()
 
@@ -154,7 +154,7 @@ class TestMapOverSubTree:
         result = add(dt1, value=dt2)
         assert_equal(result, expected)
 
-    def test_return_multiple_dts(self):
+    def test_return_multiple_dts(self, create_test_datatree):
         dt = create_test_datatree()
 
         @map_over_subtree
@@ -167,8 +167,8 @@ class TestMapOverSubTree:
         expected_max = create_test_datatree(modify=lambda ds: ds.max())
         assert_equal(dt_max, expected_max)
 
-    def test_return_wrong_type(self):
-        dt1 = create_test_datatree()
+    def test_return_wrong_type(self, simple_datatree):
+        dt1 = simple_datatree
 
         @map_over_subtree
         def bad_func(ds1):
@@ -177,8 +177,8 @@ class TestMapOverSubTree:
         with pytest.raises(TypeError, match="not Dataset or DataArray"):
             bad_func(dt1)
 
-    def test_return_tuple_of_wrong_types(self):
-        dt1 = create_test_datatree()
+    def test_return_tuple_of_wrong_types(self, simple_datatree):
+        dt1 = simple_datatree
 
         @map_over_subtree
         def bad_func(ds1):
@@ -188,20 +188,20 @@ class TestMapOverSubTree:
             bad_func(dt1)
 
     @pytest.mark.xfail
-    def test_return_inconsistent_number_of_results(self):
-        dt1 = create_test_datatree()
+    def test_return_inconsistent_number_of_results(self, simple_datatree):
+        dt1 = simple_datatree
 
         @map_over_subtree
         def bad_func(ds):
-            # Datasets in create_test_datatree() have different numbers of dims
+            # Datasets in simple_datatree have different numbers of dims
             # TODO need to instead return different numbers of Dataset objects for this test to catch the intended error
             return tuple(ds.dims)
 
         with pytest.raises(TypeError, match="instead returns"):
             bad_func(dt1)
 
-    def test_wrong_number_of_arguments_for_func(self):
-        dt = create_test_datatree()
+    def test_wrong_number_of_arguments_for_func(self, simple_datatree):
+        dt = simple_datatree
 
         @map_over_subtree
         def times_ten(ds):
@@ -212,7 +212,7 @@ class TestMapOverSubTree:
         ):
             times_ten(dt, dt)
 
-    def test_map_single_dataset_against_whole_tree(self):
+    def test_map_single_dataset_against_whole_tree(self, create_test_datatree):
         dt = create_test_datatree()
 
         @map_over_subtree
@@ -229,7 +229,7 @@ class TestMapOverSubTree:
         # TODO test this after I've got good tests for renaming nodes
         raise NotImplementedError
 
-    def test_dt_method(self):
+    def test_dt_method(self, create_test_datatree):
         dt = create_test_datatree()
 
         def multiply_then_add(ds, times, add=0.0):
@@ -239,7 +239,7 @@ class TestMapOverSubTree:
         result_tree = dt.map_over_subtree(multiply_then_add, 10.0, add=2.0)
         assert_equal(result_tree, expected)
 
-    def test_discard_ancestry(self):
+    def test_discard_ancestry(self, create_test_datatree):
         # Check for datatree GH issue #48
         dt = create_test_datatree()
         subtree = dt["set1"]

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -5,7 +5,6 @@ from datatree.datatree import DataTree
 from datatree.mapping import TreeIsomorphismError, check_isomorphic, map_over_subtree
 from datatree.testing import assert_equal
 
-
 empty = xr.Dataset()
 
 

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -5,7 +5,6 @@ from datatree.datatree import DataTree
 from datatree.mapping import TreeIsomorphismError, check_isomorphic, map_over_subtree
 from datatree.testing import assert_equal
 
-from .test_datatree import create_test_datatree, simple_datatree
 
 empty = xr.Dataset()
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -38,6 +38,9 @@ Documentation
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Made ``testing.test_datatree.create_test_datatree`` into a pytest fixture (:pull:`107`).
+  By `Benjamin Woods <https://github.com/benjaminwoods>`_.
+
 
 .. _whats-new.v0.0.6:
 


### PR DESCRIPTION
Make `create_test_datatree` a fully fledged pytest fixture.

* `create_test_datatree` moved from `test_datatree.py` to folder level `conftest.py`, and converted to fixture.
  * To use the fixture, add `create_test_datatree` to your test signature, then invoke it within your test.
* Added secondary utility fixture for ease, `simple_datatree` (also in folder level `conftest.py`).
  * This is the result from calling `create_test_datatree()`
  * As the fixture is initialized once per test module, this gives some performance benefits for test speed (the same pointer is thrown around).
  * Accordingly, one should only use this fixture if no in place modifications are performed on the DataTree.

This makes it easier to add more unit tests. (I found that it was a bit tricky to find an example DataTree to use for tests.) Allows for future control of setup and teardown of test data.

From a fresh clone, I was getting the following test failing in my fork:
```
FAILED datatree/tests/test_formatting.py::TestDiffFormatting::test_diff_node_data - AssertionError
```

This test is still failing for me. No delta, so I'm still submitting this PR. I'll make a bug issue for that test if I get time.

- [x] Passes `pre-commit run --all-files`