### PR TITLE
Enable tree-style HTML representation

### DIFF
--- a/datatree/formatting_html.py
+++ b/datatree/formatting_html.py
@@ -14,17 +14,18 @@ from xarray.core.options import OPTIONS
 
 OPTIONS["display_expand_groups"] = "default"
 
-
 def summarize_children(children: Mapping[str, Any]) -> str:
-    children_li = "".join(
-        f"<ul class='xr-sections'>{node_repr(n, c)}</ul>" for n, c in children.items()
+    children_html = "".join(
+        _wrapped_node_repr(n, c, end=False)                          # Long lines
+        if i < len(children)-1 else _wrapped_node_repr(n, c, end=True) # Short lines
+        for i, (n, c) in enumerate(children.items())
     )
 
-    return (
-        "<ul class='xr-sections'>"
-        f"<div style='padding-left:2rem;'>{children_li}<br></div>"
-        "</ul>"
-    )
+    return "".join([
+        "<div style='display: inline-grid; grid-template-columns: 100%'>",
+            children_html,
+        "</div>"
+    ])
 
 
 children_section = partial(
@@ -34,7 +35,6 @@ children_section = partial(
     max_items_collapse=1,
     expand_option_name="display_expand_groups",
 )
-
 
 def node_repr(group_title: str, dt: Any) -> str:
     header_components = [f"<div class='xr-obj-type'>{escape(group_title)}</div>"]
@@ -50,6 +50,42 @@ def node_repr(group_title: str, dt: Any) -> str:
     ]
 
     return _obj_repr(ds, header_components, sections)
+
+def _wrapped_node_repr(*args, end=False, **kwargs):
+    # Get node repr
+    r = node_repr(*args, **kwargs)
+
+    # height of line
+    end = bool(end)
+    height = "100%" if end is False else "1.2em";
+    return "".join([
+        "<div style='display: inline-grid;'>",
+            "<div style='",
+                "grid-column-start: 1;",
+                "border-right: 0.2em solid;",
+                "border-color: var(--xr-border-color);",
+                f"height: {height};",
+                "width: 0px;",
+            "'>",
+            "</div>",
+            "<div style='",
+                "grid-column-start: 2;",
+                "grid-row-start: 1;",
+                "height: 1em;",
+                "width: 20px;",
+                "border-bottom: 0.2em solid;",
+                "border-color: var(--xr-border-color);",
+            "'>",
+            "</div>",
+            "<div style='",
+                "grid-column-start: 3;",
+            "'>",
+                "<ul class='xr-sections'>",
+                    r,
+                "</ul>"
+            "</div>",
+        "</div>",
+    ])
 
 
 def datatree_repr(dt: Any) -> str:

--- a/datatree/formatting_html.py
+++ b/datatree/formatting_html.py
@@ -14,26 +14,27 @@ from xarray.core.options import OPTIONS
 
 OPTIONS["display_expand_groups"] = "default"
 
+
 def summarize_children(children: Mapping[str, Any]) -> str:
     N_CHILDREN = len(children) - 1
 
     # Get result from node_repr and wrap it
-    lines_callback = lambda n, c, end: _wrap_repr(
-        node_repr(n, c), end=end
-    )
+    lines_callback = lambda n, c, end: _wrap_repr(node_repr(n, c), end=end)
 
     children_html = "".join(
-        lines_callback(n, c, end=False)                         # Long lines
+        lines_callback(n, c, end=False)  # Long lines
         if i < N_CHILDREN
-        else lines_callback(n, c, end=True)                     # Short lines
+        else lines_callback(n, c, end=True)  # Short lines
         for i, (n, c) in enumerate(children.items())
     )
 
-    return "".join([
-        "<div style='display: inline-grid; grid-template-columns: 100%'>",
+    return "".join(
+        [
+            "<div style='display: inline-grid; grid-template-columns: 100%'>",
             children_html,
-        "</div>"
-    ])
+            "</div>",
+        ]
+    )
 
 
 children_section = partial(
@@ -43,6 +44,7 @@ children_section = partial(
     max_items_collapse=1,
     expand_option_name="display_expand_groups",
 )
+
 
 def node_repr(group_title: str, dt: Any) -> str:
     header_components = [f"<div class='xr-obj-type'>{escape(group_title)}</div>"]
@@ -58,6 +60,7 @@ def node_repr(group_title: str, dt: Any) -> str:
     ]
 
     return _obj_repr(ds, header_components, sections)
+
 
 def _wrap_repr(r: str, end: bool = False) -> str:
     """
@@ -98,35 +101,36 @@ def _wrap_repr(r: str, end: bool = False) -> str:
     """
     # height of line
     end = bool(end)
-    height = "100%" if end is False else "1.2em";
-    return "".join([
-        "<div style='display: inline-grid;'>",
+    height = "100%" if end is False else "1.2em"
+    return "".join(
+        [
+            "<div style='display: inline-grid;'>",
             "<div style='",
-                "grid-column-start: 1;",
-                "border-right: 0.2em solid;",
-                "border-color: var(--xr-border-color);",
-                f"height: {height};",
-                "width: 0px;",
+            "grid-column-start: 1;",
+            "border-right: 0.2em solid;",
+            "border-color: var(--xr-border-color);",
+            f"height: {height};",
+            "width: 0px;",
             "'>",
             "</div>",
             "<div style='",
-                "grid-column-start: 2;",
-                "grid-row-start: 1;",
-                "height: 1em;",
-                "width: 20px;",
-                "border-bottom: 0.2em solid;",
-                "border-color: var(--xr-border-color);",
+            "grid-column-start: 2;",
+            "grid-row-start: 1;",
+            "height: 1em;",
+            "width: 20px;",
+            "border-bottom: 0.2em solid;",
+            "border-color: var(--xr-border-color);",
             "'>",
             "</div>",
             "<div style='",
-                "grid-column-start: 3;",
+            "grid-column-start: 3;",
             "'>",
-                "<ul class='xr-sections'>",
-                    r,
-                "</ul>"
+            "<ul class='xr-sections'>",
+            r,
+            "</ul>" "</div>",
             "</div>",
-        "</div>",
-    ])
+        ]
+    )
 
 
 def datatree_repr(dt: Any) -> str:

--- a/datatree/tests/test_formatting_html.py
+++ b/datatree/tests/test_formatting_html.py
@@ -1,18 +1,19 @@
 import pytest
 import xarray as xr
 
-from datatree import DataTree
+from datatree import DataTree, formatting_html
 
-from datatree import formatting_html
 
 @pytest.fixture(scope="module", params=["some html", "some other html"])
 def repr(request):
     return request.param
 
+
 class Test_summarize_children:
     """
     Unit tests for summarize_children.
     """
+
     func = staticmethod(formatting_html.summarize_children)
 
     @pytest.fixture(scope="class")
@@ -21,11 +22,14 @@ class Test_summarize_children:
         Fixture for a child-free DataTree factory.
         """
         from random import randint
+
         def _childfree_tree_factory():
-            return DataTree(data=xr.Dataset(
-                {"z": ("y", [randint(1,100) for _ in range(3)])}
-            ))
+            return DataTree(
+                data=xr.Dataset({"z": ("y", [randint(1, 100) for _ in range(3)])})
+            )
+
         return _childfree_tree_factory
+
     @pytest.fixture(scope="class")
     def childfree_tree(self, childfree_tree_factory):
         """
@@ -38,7 +42,7 @@ class Test_summarize_children:
         """
         Apply mocking for node_repr.
         """
-        from hashlib import sha1
+
         def mock(group_title, dt):
             """
             Mock with a simple result
@@ -52,12 +56,12 @@ class Test_summarize_children:
         """
         Apply mocking for _wrap_repr.
         """
-        from hashlib import sha1
+
         def mock(r, *, end, **kwargs):
             """
             Mock by appending "end" or "not end".
             """
-            return r + " " + ("end" if end else "not end") +"//"
+            return r + " " + ("end" if end else "not end") + "//"
 
         monkeypatch.setattr(formatting_html, "_wrap_repr", mock)
 
@@ -67,8 +71,7 @@ class Test_summarize_children:
         """
         children = {}
         assert self.func(children) == (
-            "<div style='display: inline-grid; grid-template-columns: 100%'>"
-            "</div>"
+            "<div style='display: inline-grid; grid-template-columns: 100%'>" "</div>"
         )
 
     def test_one_child(self, childfree_tree, mock_wrap_repr, mock_node_repr):
@@ -79,9 +82,7 @@ class Test_summarize_children:
         the inline lambda function "lines_callback".
         """
         # Create mapping of children
-        children = {
-            "a": childfree_tree
-        }
+        children = {"a": childfree_tree}
 
         # Expect first line to be produced from the first child, and
         # wrapped as the last child
@@ -89,7 +90,7 @@ class Test_summarize_children:
 
         assert self.func(children) == (
             "<div style='display: inline-grid; grid-template-columns: 100%'>"
-                f"{first_line}"
+            f"{first_line}"
             "</div>"
         )
 
@@ -102,10 +103,7 @@ class Test_summarize_children:
         """
 
         # Create mapping of children
-        children = {
-            "a": childfree_tree_factory(),
-            "b": childfree_tree_factory()
-        }
+        children = {"a": childfree_tree_factory(), "b": childfree_tree_factory()}
 
         # Expect first line to be produced from the first child, and
         # wrapped as _not_ the last child
@@ -117,8 +115,8 @@ class Test_summarize_children:
 
         assert self.func(children) == (
             "<div style='display: inline-grid; grid-template-columns: 100%'>"
-                f"{first_line}"
-                f"{second_line}"
+            f"{first_line}"
+            f"{second_line}"
             "</div>"
         )
 
@@ -127,6 +125,7 @@ class Test__wrap_repr:
     """
     Unit tests for _wrap_repr.
     """
+
     func = staticmethod(formatting_html._wrap_repr)
 
     def test_end(self, repr):
@@ -136,30 +135,30 @@ class Test__wrap_repr:
         r = self.func(repr, end=True)
         assert r == (
             "<div style='display: inline-grid;'>"
-                "<div style='"
-                    "grid-column-start: 1;"
-                    "border-right: 0.2em solid;"
-                    "border-color: var(--xr-border-color);"
-                    "height: 1.2em;"
-                    "width: 0px;"
-                "'>"
-                "</div>"
-                "<div style='"
-                    "grid-column-start: 2;"
-                    "grid-row-start: 1;"
-                    "height: 1em;"
-                    "width: 20px;"
-                    "border-bottom: 0.2em solid;"
-                    "border-color: var(--xr-border-color);"
-                "'>"
-                "</div>"
-                "<div style='"
-                    "grid-column-start: 3;"
-                "'>"
-                    "<ul class='xr-sections'>"
-                        f"{repr}"
-                    "</ul>"
-                "</div>"
+            "<div style='"
+            "grid-column-start: 1;"
+            "border-right: 0.2em solid;"
+            "border-color: var(--xr-border-color);"
+            "height: 1.2em;"
+            "width: 0px;"
+            "'>"
+            "</div>"
+            "<div style='"
+            "grid-column-start: 2;"
+            "grid-row-start: 1;"
+            "height: 1em;"
+            "width: 20px;"
+            "border-bottom: 0.2em solid;"
+            "border-color: var(--xr-border-color);"
+            "'>"
+            "</div>"
+            "<div style='"
+            "grid-column-start: 3;"
+            "'>"
+            "<ul class='xr-sections'>"
+            f"{repr}"
+            "</ul>"
+            "</div>"
             "</div>"
         )
 
@@ -170,29 +169,29 @@ class Test__wrap_repr:
         r = self.func(repr, end=False)
         assert r == (
             "<div style='display: inline-grid;'>"
-                "<div style='"
-                    "grid-column-start: 1;"
-                    "border-right: 0.2em solid;"
-                    "border-color: var(--xr-border-color);"
-                    "height: 100%;"
-                    "width: 0px;"
-                "'>"
-                "</div>"
-                "<div style='"
-                    "grid-column-start: 2;"
-                    "grid-row-start: 1;"
-                    "height: 1em;"
-                    "width: 20px;"
-                    "border-bottom: 0.2em solid;"
-                    "border-color: var(--xr-border-color);"
-                "'>"
-                "</div>"
-                "<div style='"
-                    "grid-column-start: 3;"
-                "'>"
-                    "<ul class='xr-sections'>"
-                        f"{repr}"
-                    "</ul>"
-                "</div>"
+            "<div style='"
+            "grid-column-start: 1;"
+            "border-right: 0.2em solid;"
+            "border-color: var(--xr-border-color);"
+            "height: 100%;"
+            "width: 0px;"
+            "'>"
+            "</div>"
+            "<div style='"
+            "grid-column-start: 2;"
+            "grid-row-start: 1;"
+            "height: 1em;"
+            "width: 20px;"
+            "border-bottom: 0.2em solid;"
+            "border-color: var(--xr-border-color);"
+            "'>"
+            "</div>"
+            "<div style='"
+            "grid-column-start: 3;"
+            "'>"
+            "<ul class='xr-sections'>"
+            f"{repr}"
+            "</ul>"
+            "</div>"
             "</div>"
         )

--- a/datatree/tests/test_formatting_html.py
+++ b/datatree/tests/test_formatting_html.py
@@ -1,0 +1,198 @@
+import pytest
+import xarray as xr
+
+from datatree import DataTree
+
+from datatree import formatting_html
+
+@pytest.fixture(scope="module", params=["some html", "some other html"])
+def repr(request):
+    return request.param
+
+class Test_summarize_children:
+    """
+    Unit tests for summarize_children.
+    """
+    func = staticmethod(formatting_html.summarize_children)
+
+    @pytest.fixture(scope="class")
+    def childfree_tree_factory(self):
+        """
+        Fixture for a child-free DataTree factory.
+        """
+        from random import randint
+        def _childfree_tree_factory():
+            return DataTree(data=xr.Dataset(
+                {"z": ("y", [randint(1,100) for _ in range(3)])}
+            ))
+        return _childfree_tree_factory
+    @pytest.fixture(scope="class")
+    def childfree_tree(self, childfree_tree_factory):
+        """
+        Fixture for a child-free DataTree.
+        """
+        return childfree_tree_factory()
+
+    @pytest.fixture(scope="function")
+    def mock_node_repr(self, monkeypatch):
+        """
+        Apply mocking for node_repr.
+        """
+        from hashlib import sha1
+        def mock(group_title, dt):
+            """
+            Mock with a simple result
+            """
+            return group_title + " " + str(id(dt))
+
+        monkeypatch.setattr(formatting_html, "node_repr", mock)
+
+    @pytest.fixture(scope="function")
+    def mock_wrap_repr(self, monkeypatch):
+        """
+        Apply mocking for _wrap_repr.
+        """
+        from hashlib import sha1
+        def mock(r, *, end, **kwargs):
+            """
+            Mock by appending "end" or "not end".
+            """
+            return r + " " + ("end" if end else "not end") +"//"
+
+        monkeypatch.setattr(formatting_html, "_wrap_repr", mock)
+
+    def test_empty_mapping(self):
+        """
+        Test with an empty mapping of children.
+        """
+        children = {}
+        assert self.func(children) == (
+            "<div style='display: inline-grid; grid-template-columns: 100%'>"
+            "</div>"
+        )
+
+    def test_one_child(self, childfree_tree, mock_wrap_repr, mock_node_repr):
+        """
+        Test with one child.
+
+        Uses a mock of _wrap_repr and node_repr to essentially mock
+        the inline lambda function "lines_callback".
+        """
+        # Create mapping of children
+        children = {
+            "a": childfree_tree
+        }
+
+        # Expect first line to be produced from the first child, and
+        # wrapped as the last child
+        first_line = f"a {id(children['a'])} end//"
+
+        assert self.func(children) == (
+            "<div style='display: inline-grid; grid-template-columns: 100%'>"
+                f"{first_line}"
+            "</div>"
+        )
+
+    def test_two_children(self, childfree_tree_factory, mock_wrap_repr, mock_node_repr):
+        """
+        Test with two level deep children.
+
+        Uses a mock of _wrap_repr and node_repr to essentially mock
+        the inline lambda function "lines_callback".
+        """
+
+        # Create mapping of children
+        children = {
+            "a": childfree_tree_factory(),
+            "b": childfree_tree_factory()
+        }
+
+        # Expect first line to be produced from the first child, and
+        # wrapped as _not_ the last child
+        first_line = f"a {id(children['a'])} not end//"
+
+        # Expect second line to be produced from the second child, and
+        # wrapped as the last child
+        second_line = f"b {id(children['b'])} end//"
+
+        assert self.func(children) == (
+            "<div style='display: inline-grid; grid-template-columns: 100%'>"
+                f"{first_line}"
+                f"{second_line}"
+            "</div>"
+        )
+
+
+class Test__wrap_repr:
+    """
+    Unit tests for _wrap_repr.
+    """
+    func = staticmethod(formatting_html._wrap_repr)
+
+    def test_end(self, repr):
+        """
+        Test with end=True.
+        """
+        r = self.func(repr, end=True)
+        assert r == (
+            "<div style='display: inline-grid;'>"
+                "<div style='"
+                    "grid-column-start: 1;"
+                    "border-right: 0.2em solid;"
+                    "border-color: var(--xr-border-color);"
+                    "height: 1.2em;"
+                    "width: 0px;"
+                "'>"
+                "</div>"
+                "<div style='"
+                    "grid-column-start: 2;"
+                    "grid-row-start: 1;"
+                    "height: 1em;"
+                    "width: 20px;"
+                    "border-bottom: 0.2em solid;"
+                    "border-color: var(--xr-border-color);"
+                "'>"
+                "</div>"
+                "<div style='"
+                    "grid-column-start: 3;"
+                "'>"
+                    "<ul class='xr-sections'>"
+                        f"{repr}"
+                    "</ul>"
+                "</div>"
+            "</div>"
+        )
+
+    def test_not_end(self, repr):
+        """
+        Test with end=False.
+        """
+        r = self.func(repr, end=False)
+        assert r == (
+            "<div style='display: inline-grid;'>"
+                "<div style='"
+                    "grid-column-start: 1;"
+                    "border-right: 0.2em solid;"
+                    "border-color: var(--xr-border-color);"
+                    "height: 100%;"
+                    "width: 0px;"
+                "'>"
+                "</div>"
+                "<div style='"
+                    "grid-column-start: 2;"
+                    "grid-row-start: 1;"
+                    "height: 1em;"
+                    "width: 20px;"
+                    "border-bottom: 0.2em solid;"
+                    "border-color: var(--xr-border-color);"
+                "'>"
+                "</div>"
+                "<div style='"
+                    "grid-column-start: 3;"
+                "'>"
+                    "<ul class='xr-sections'>"
+                        f"{repr}"
+                    "</ul>"
+                "</div>"
+            "</div>"
+        )

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -23,6 +23,9 @@ v0.0.7 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Improve the HTML repr by adding tree-style lines connecting groups and sub-groups (:pull:`109`).
+  By `Benjamin Woods <https://github.com/benjaminwoods>`_.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Enable tree-style HTML representation.

(see #87 for a quick screenshot, produced by manually producing the HTML repr and dumping to file)

`black` shredded the indentation for the HTML stuff (lines 107 - 131 in formatting_html.py) -- if you want it back for readability, there are always tricks.

## logic

Achieved using roughly the following logic:

```mermaid
graph TD
    datatree_repr --> node_repr
    node_repr -->|via _obj_repr| summarize_children
    summarize_children --> _wrap_repr
    _wrap_repr --> node_repr
    
    style summarize_children fill:#c60
    style _wrap_repr fill:#0a0
```

Overall, this moves the padding logic out of `summarize_children` and into `_wrap_repr`.
* `_wrap_repr` is a new internal function that wraps the result from `node_repr`, or elsewhere, and adds some HTML wrapping.
* `summarize_children` modified to:
  * Make a call to `_wrap_repr` instead of `node_repr` directly
  * Move HTML padding logic into `_wrap_repr` (and replace with this tree HTML code instead)

## .rst files

`_wrap_repr` is a purely internal function, and so I don't imagine you'll want to include it in `api.rst`.

No changes made to docs/source/whats-new.rst yet.

## tests

Added tests for new `_wrap_repr` function, as well as some tests for `summarize_children`.

For `summarize_children` tests, I've mocked the new `_wrap_repr` function as well as `node_repr` in some of the tests; this should make the tests a bit more lightweight and easier to manage. (Trying to avoid huge strings where not necessary.) In principle the function is wrapping the result from `_wrap_repr`, so we can mock to make life a bit easier. The mock should allow one to map fairly reliably from input to output, for further tests.


- [x] Closes #87
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] New functions/methods are listed in `api.rst`
- [x] Changes are summarized in `docs/source/whats-new.rst`
