### PR TITLE
implement open_datatree context manager

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -345,12 +345,10 @@ class DataTree(
 
     def close(self) -> None:
         """Release any resources linked to this object."""
-        if self._close is not None:
-            self._close()
-        self._close = None
-
-        for child in self._children.values():
-            child.close()
+        for node in self.subtree:
+            if node._close is not None:
+                node._close()
+            node._close = None
 
     def __enter__(self: DataTree) -> DataTree:
         return self

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -341,7 +341,29 @@ class DataTree(
             attrs=ds._attrs,
             encoding=ds._encoding,
         )
-        self._close = ds._close
+        self._close = None if data is None else data._close
+
+    def close(self) -> None:
+        """Release any resources linked to this object."""
+        if self._close is not None:
+            self._close()
+        self._close = None
+
+        if self._parent is not None:
+            if self._parent._close is not None:
+                self._parent._close()
+            self._parent._close = None
+
+        for child in self._children.values():
+            if child._close is not None:
+                child._close()
+            child._close = None
+
+    def __enter__(self: DataTree) -> DataTree:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
 
     @property
     def name(self) -> str | None:

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -349,15 +349,8 @@ class DataTree(
             self._close()
         self._close = None
 
-        if self._parent is not None:
-            if self._parent._close is not None:
-                self._parent._close()
-            self._parent._close = None
-
         for child in self._children.values():
-            if child._close is not None:
-                child._close()
-            child._close = None
+            child.close()
 
     def __enter__(self: DataTree) -> DataTree:
         return self

--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -74,8 +74,9 @@ def datatree_repr(dt):
     # Tack on info about whether or not root node has a parent at the start
     first_line = lines[0]
     parent = f'"{dt.parent.name}"' if dt.parent is not None else "None"
-    first_line_with_parent = first_line[:-1] + f", parent={parent})"
-    lines[0] = first_line_with_parent
+    open = dt._close is not None
+    first_line_with_extras = first_line[:-1] + f", parent={parent}, open={open})"
+    lines[0] = first_line_with_extras
 
     return "\n".join(lines)
 

--- a/datatree/formatting.py
+++ b/datatree/formatting.py
@@ -74,8 +74,8 @@ def datatree_repr(dt):
     # Tack on info about whether or not root node has a parent at the start
     first_line = lines[0]
     parent = f'"{dt.parent.name}"' if dt.parent is not None else "None"
-    open = dt._close is not None
-    first_line_with_extras = first_line[:-1] + f", parent={parent}, open={open})"
+    is_open = dt._close is not None
+    first_line_with_extras = first_line[:-1] + f", parent={parent}, open={is_open})"
     lines[0] = first_line_with_extras
 
     return "\n".join(lines)

--- a/datatree/tests/test_formatting.py
+++ b/datatree/tests/test_formatting.py
@@ -10,7 +10,7 @@ class TestRepr:
     def test_print_empty_node(self):
         dt = DataTree(name="root")
         printout = dt.__str__()
-        assert printout == "DataTree('root', parent=None)"
+        assert printout == "DataTree('root', parent=None, open=False)"
 
     def test_print_empty_node_with_attrs(self):
         dat = Dataset(attrs={"note": "has attrs"})
@@ -18,7 +18,7 @@ class TestRepr:
         printout = dt.__str__()
         assert printout == dedent(
             """\
-            DataTree('root', parent=None)
+            DataTree('root', parent=None, open=False)
                 Dimensions:  ()
                 Data variables:
                     *empty*
@@ -31,7 +31,7 @@ class TestRepr:
         dt = DataTree(name="root", data=dat)
         printout = dt.__str__()
         expected = [
-            "DataTree('root', parent=None)",
+            "DataTree('root', parent=None, open=False)",
             "Dimensions",
             "Coordinates",
             "a",

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -18,6 +18,20 @@ class TestIO:
             assert_equal(original_dt, roundtrip_dt)
 
     @requires_netCDF4
+    def test_close(self, tmpdir, simple_datatree):
+        filepath = str(
+            tmpdir / "test.nc"
+        )  # casting to str avoids a pathlib bug in xarray
+        dt = simple_datatree
+        dt.to_netcdf(filepath, engine="netcdf4")
+
+        roundtrip_dt = open_datatree(filepath)
+        assert all([node._close is not None for node in roundtrip_dt.subtree])
+
+        roundtrip_dt.close()
+        assert all([node._close is None for node in roundtrip_dt.subtree])
+
+    @requires_netCDF4
     def test_netcdf_encoding(self, tmpdir, simple_datatree):
         filepath = str(
             tmpdir / "test.nc"

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -14,8 +14,8 @@ class TestIO:
         original_dt = simple_datatree
         original_dt.to_netcdf(filepath, engine="netcdf4")
 
-        roundtrip_dt = open_datatree(filepath)
-        assert_equal(original_dt, roundtrip_dt)
+        with open_datatree(filepath) as roundtrip_dt:
+            assert_equal(original_dt, roundtrip_dt)
 
     @requires_netCDF4
     def test_netcdf_encoding(self, tmpdir, simple_datatree):
@@ -29,10 +29,9 @@ class TestIO:
         enc = {"/set2": {var: comp for var in original_dt["/set2"].ds.data_vars}}
 
         original_dt.to_netcdf(filepath, encoding=enc, engine="netcdf4")
-        roundtrip_dt = open_datatree(filepath)
-
-        assert roundtrip_dt["/set2/a"].encoding["zlib"] == comp["zlib"]
-        assert roundtrip_dt["/set2/a"].encoding["complevel"] == comp["complevel"]
+        with open_datatree(filepath) as roundtrip_dt:
+            assert roundtrip_dt["/set2/a"].encoding["zlib"] == comp["zlib"]
+            assert roundtrip_dt["/set2/a"].encoding["complevel"] == comp["complevel"]
 
         enc["/not/a/group"] = {"foo": "bar"}
         with pytest.raises(ValueError, match="unexpected encoding group.*"):
@@ -46,8 +45,8 @@ class TestIO:
         original_dt = simple_datatree
         original_dt.to_netcdf(filepath, engine="h5netcdf")
 
-        roundtrip_dt = open_datatree(filepath)
-        assert_equal(original_dt, roundtrip_dt)
+        with open_datatree(filepath) as roundtrip_dt:
+            assert_equal(original_dt, roundtrip_dt)
 
     @requires_zarr
     def test_to_zarr(self, tmpdir, simple_datatree):
@@ -57,8 +56,8 @@ class TestIO:
         original_dt = simple_datatree
         original_dt.to_zarr(filepath)
 
-        roundtrip_dt = open_datatree(filepath, engine="zarr")
-        assert_equal(original_dt, roundtrip_dt)
+        with open_datatree(filepath, engine="zarr") as roundtrip_dt:
+            assert_equal(original_dt, roundtrip_dt)
 
     @requires_zarr
     def test_zarr_encoding(self, tmpdir, simple_datatree):
@@ -72,10 +71,9 @@ class TestIO:
         comp = {"compressor": zarr.Blosc(cname="zstd", clevel=3, shuffle=2)}
         enc = {"/set2": {var: comp for var in original_dt["/set2"].ds.data_vars}}
         original_dt.to_zarr(filepath, encoding=enc)
-        roundtrip_dt = open_datatree(filepath, engine="zarr")
 
-        print(roundtrip_dt["/set2/a"].encoding)
-        assert roundtrip_dt["/set2/a"].encoding["compressor"] == comp["compressor"]
+        with open_datatree(filepath, engine="zarr") as roundtrip_dt:
+            assert roundtrip_dt["/set2/a"].encoding["compressor"] == comp["compressor"]
 
         enc["/not/a/group"] = {"foo": "bar"}
         with pytest.raises(ValueError, match="unexpected encoding group.*"):
@@ -92,8 +90,8 @@ class TestIO:
         store = ZipStore(filepath)
         original_dt.to_zarr(store)
 
-        roundtrip_dt = open_datatree(store, engine="zarr")
-        assert_equal(original_dt, roundtrip_dt)
+        with open_datatree(store, engine="zarr") as roundtrip_dt:
+            assert_equal(original_dt, roundtrip_dt)
 
     @requires_zarr
     def test_to_zarr_not_consolidated(self, tmpdir, simple_datatree):
@@ -107,5 +105,5 @@ class TestIO:
         assert not s1zmetadata.exists()
 
         with pytest.warns(RuntimeWarning, match="consolidated"):
-            roundtrip_dt = open_datatree(filepath, engine="zarr")
-        assert_equal(original_dt, roundtrip_dt)
+            with open_datatree(filepath, engine="zarr") as roundtrip_dt:
+                assert_equal(original_dt, roundtrip_dt)

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -26,10 +26,10 @@ class TestIO:
         dt.to_netcdf(filepath, engine="netcdf4")
 
         roundtrip_dt = open_datatree(filepath)
-        assert all([node._close is not None for node in roundtrip_dt.subtree])
+        assert all(node._close is not None for node in roundtrip_dt.subtree)
 
         roundtrip_dt.close()
-        assert all([node._close is None for node in roundtrip_dt.subtree])
+        assert all(node._close is None for node in roundtrip_dt.subtree)
 
     @requires_netCDF4
     def test_netcdf_encoding(self, tmpdir, simple_datatree):


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #93 
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] New functions/methods are listed in `api.rst`
- [ ] Changes are summarized in `docs/source/whats-new.rst`

I haven't added any test, but the io tests now use the context manager. Not sure if there's a better way to test this functionality.