### PR TITLE
actually allow `DataTree` objects as values in `from_dict`

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -754,7 +754,7 @@ class DataTree(
     @classmethod
     def from_dict(
         cls,
-        d: MutableMapping[str, Dataset | DataArray | None],
+        d: MutableMapping[str, Dataset | DataArray | DataTree | None],
         name: str = None,
     ) -> DataTree:
         """
@@ -790,7 +790,11 @@ class DataTree(
             for path, data in d.items():
                 # Create and set new node
                 node_name = NodePath(path).name
-                new_node = cls(name=node_name, data=data)
+                if isinstance(data, cls):
+                    new_node = data.copy()
+                    new_node.orphan()
+                else:
+                    new_node = cls(name=node_name, data=data)
                 obj._set_item(
                     path,
                     new_node,

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -791,7 +791,8 @@ class DataTree(
                 # Create and set new node
                 node_name = NodePath(path).name
                 if isinstance(data, cls):
-                    new_node = data.copy()
+                    # TODO ignoring type error only needed whilst .copy() method is copied from Dataset.copy().
+                    new_node = data.copy()  # type: ignore[attr-defined]
                     new_node.orphan()
                 else:
                     new_node = cls(name=node_name, data=data)

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -391,6 +391,15 @@ class TestTreeFromDict:
             "/set3",
         ]
 
+    def test_datatree_values(self):
+        dat1 = DataTree(data=xr.Dataset({"a": 1}))
+        expected = DataTree()
+        expected["a"] = dat1
+
+        actual = DataTree.from_dict({"a": dat1})
+
+        dtt.assert_identical(actual, expected)
+
     def test_roundtrip(self, simple_datatree):
         dt = simple_datatree
         roundtrip = DataTree.from_dict(dt.to_dict())

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -37,6 +37,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Allow ``Datatree`` objects as values in :py:meth:`DataTree.from_dict` (:pull:`159`).
+  By `Justus Magin <https://github.com/keewis>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
The docstring of `DataTree.from_dict` claims that it allows having `DataTree` objects as values, but both the type hints and the code disagree (the code fails because `DataTree(DataTree())` does not work).

The implementation I chose in this PR is to special-case `DataTree` objects to copy and orphan the node instead of passing it to the `DataTree` constructor.

Apparently this does not please `mypy` because while `DataTree` has a `copy` method, that is inherited from `Dataset`. The `copy` is only necessary because `orphan` works in-place (but then again you'd probably need `copy` to implement a side-effect free `orphan`).

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [x] Changes are summarized in `docs/source/whats-new.rst`

For reference, I'm currently working around this limitation using
```python
import posixpath

def normalize_tree_dict(mapping):
    def _normalize(mapping):
        for path, item in mapping.items():
            if not isinstance(item, datatree.DataTree):
                yield path, item
            else:
                root = item.copy()
                root.orphan()
                yield from ((posixpath.join(path, node.path), node.ds) for node in root.subtree)
            
    return dict(_normalize(mapping))

d = {"/path/to/node1": node1, "/path/to/node2": node2}
datatree.DataTree.from_dict(normalize_tree_dict(d))
```