### PR TITLE
Improved exception types

### DIFF
--- a/datatree/__init__.py
+++ b/datatree/__init__.py
@@ -3,6 +3,7 @@ from .datatree import DataTree
 from .extensions import register_datatree_accessor
 from .io import open_datatree
 from .mapping import TreeIsomorphismError, map_over_subtree
+from .treenode import InvalidTreeError, NotFoundInTreeError
 
 try:
     # NOTE: the `_version.py` file must not be present in the git repository
@@ -16,6 +17,8 @@ __all__ = (
     "DataTree",
     "open_datatree",
     "TreeIsomorphismError",
+    "InvalidTreeError",
+    "NotFoundInTreeError",
     "map_over_subtree",
     "register_datatree_accessor",
     "__version__",

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -7,7 +7,7 @@ import xarray.testing as xrt
 from xarray.tests import create_test_data, source_ndarray
 
 import datatree.testing as dtt
-from datatree import DataTree
+from datatree import DataTree, NotFoundInTreeError
 
 
 class TestTreeCreation:
@@ -109,7 +109,9 @@ class TestPaths:
         assert sue.relative_to(sue) == "."
 
         evil_kate = DataTree()
-        with pytest.raises(ValueError, match="nodes do not lie within the same tree"):
+        with pytest.raises(
+            NotFoundInTreeError, match="nodes do not lie within the same tree"
+        ):
             sue.relative_to(evil_kate)
 
 

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -1,7 +1,7 @@
 import pytest
 
 from datatree.iterators import LevelOrderIter, PreOrderIter
-from datatree.treenode import NamedNode, TreeError, TreeNode
+from datatree.treenode import InvalidTreeError, NamedNode, TreeNode
 
 
 class TestFamilyTree:
@@ -21,10 +21,10 @@ class TestFamilyTree:
     def test_no_time_traveller_loops(self):
         john = TreeNode()
 
-        with pytest.raises(TreeError, match="cannot be a parent of itself"):
+        with pytest.raises(InvalidTreeError, match="cannot be a parent of itself"):
             john._set_parent(john, "John")
 
-        with pytest.raises(TreeError, match="cannot be a parent of itself"):
+        with pytest.raises(InvalidTreeError, match="cannot be a parent of itself"):
             john.children = {"John": john}
 
         mary = TreeNode()
@@ -32,10 +32,10 @@ class TestFamilyTree:
         mary._set_parent(john, "Mary")
         rose._set_parent(mary, "Rose")
 
-        with pytest.raises(TreeError, match="is already a descendant"):
+        with pytest.raises(InvalidTreeError, match="is already a descendant"):
             john._set_parent(rose, "John")
 
-        with pytest.raises(TreeError, match="is already a descendant"):
+        with pytest.raises(InvalidTreeError, match="is already a descendant"):
             rose.children = {"John": john}
 
     def test_parent_swap(self):
@@ -73,7 +73,7 @@ class TestFamilyTree:
         with pytest.raises(TypeError):
             john.children = {"Kate": 666}
 
-        with pytest.raises(TreeError, match="Cannot add same node"):
+        with pytest.raises(InvalidTreeError, match="Cannot add same node"):
             john.children = {"Kate": kate, "Evil_Kate": kate}
 
         john = TreeNode(children={"Kate": kate})

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -309,6 +309,8 @@ Exceptions raised when manipulating trees.
    :toctree: generated/
 
    TreeIsomorphismError
+   InvalidTreeError
+   NotFoundInTreeError
 
 Advanced API
 ============

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -27,6 +27,7 @@ New Features
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Allow method chaining with a new :py:meth:`DataTree.pipe` method (:issue:`151`, :pull:`156`).
   By `Justus Magin <https://github.com/keewis>`_.
+- New, more specific exception types for tree-related errors (:pull:`169`).
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Makes exception classes more specific by replacing `TreeError` with `InvalidTreeError` and `NotFoundInTreeError`.

- [ ] Closes #xxxx
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] New functions/methods are listed in `api.rst`
- [x] Changes are summarized in `docs/source/whats-new.rst`
