### PR TITLE
Added drop_nodes method

### DIFF
--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -515,7 +515,25 @@ class TestDatasetView:
 
 
 class TestRestructuring:
-    ...
+    def test_drop_nodes(self):
+        sue = DataTree.from_dict({"Mary": None, "Kate": None, "Ashley": None})
+
+        # test drop just one node
+        dropped_one = sue.drop_nodes(names="Mary")
+        assert "Mary" not in dropped_one.children
+
+        # test drop multiple nodes
+        dropped = sue.drop_nodes(names=["Mary", "Kate"])
+        assert not set(["Mary", "Kate"]).intersection(set(dropped.children))
+        assert "Ashley" in dropped.children
+
+        # test raise
+        with pytest.raises(KeyError, match="nodes {'Mary'} not present"):
+            dropped.drop_nodes(names=["Mary", "Ashley"])
+
+        # test ignore
+        childless = dropped.drop_nodes(names=["Mary", "Ashley"], errors="ignore")
+        assert childless.children == {}
 
 
 class TestPipe:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -126,6 +126,11 @@ DataTree Node Contents
 
 Manipulate the contents of a single DataTree node.
 
+.. autosummary::
+   :toctree: generated/
+
+   DataTree.drop_nodes
+
 Comparisons
 ===========
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -23,6 +23,8 @@ v0.0.11 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Added a :py:meth:`DataTree.drop_nodes` method (:issue:`161`, :pull:`175`).
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - New, more specific exception types for tree-related errors (:pull:`169`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - Added a new :py:meth:`DataTree.descendants` property (:pull:`170`).


### PR DESCRIPTION
I called it `drop_nodes` plural for consistency with `Dataset.drop_vars`.

- [x] Closes #161
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] New functions/methods are listed in `api.rst`
- [x] Changes are summarized in `docs/source/whats-new.rst`
