### PR TITLE
Try to fix code links in docs

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -11,6 +11,8 @@ dependencies:
   - sphinx-panels
   - sphinx-autosummary-accessors
   - sphinx-book-theme >= 0.0.38
+  - nbsphinx
+  - sphinxcontrib-srclinks
   - pydata-sphinx-theme>=0.4.3
   - numpydoc
   - ipython

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import inspect
 import os
 import sys
 
@@ -41,6 +42,7 @@ extensions = [
     "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.extlinks",
@@ -50,6 +52,8 @@ extensions = [
     "sphinx_autosummary_accessors",
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
+    "nbsphinx",
+    "sphinxcontrib.srclinks",
 ]
 
 extlinks = {
@@ -75,6 +79,11 @@ master_doc = "index"
 project = "Datatree"
 copyright = "2021 onwards, Tom Nicholas and its Contributors"
 author = "Tom Nicholas"
+
+html_show_sourcelink = True
+srclink_project = "https://github.com/xarray-contrib/datatree"
+srclink_branch = "main"
+srclink_src_path = "docs/source"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -127,6 +136,7 @@ pygments_style = "sphinx"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.8/", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
     "xarray": ("https://xarray.pydata.org/en/stable/", None),
 }
 
@@ -142,7 +152,7 @@ html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": "https://github.com/xarray-contrib/datatree",
     "repository_branch": "main",
-    "path_to_docs": "doc",
+    "path_to_docs": "docs/source",
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,
@@ -334,12 +344,12 @@ def linkcode_resolve(domain, info):
     else:
         linespec = ""
 
-    fn = os.path.relpath(fn, start=os.path.dirname(xarray.__file__))
+    fn = os.path.relpath(fn, start=os.path.dirname(datatree.__file__))
 
-    if "+" in xarray.__version__:
+    if "+" in datatree.__version__:
         return f"https://github.com/xarray-contrib/datatree/blob/main/datatree/{fn}{linespec}"
     else:
         return (
             f"https://github.com/xarray-contrib/datatree/blob/"
-            f"v{datatree.__version__}/xarray/{fn}{linespec}"
+            f"v{datatree.__version__}/datatree/{fn}{linespec}"
         )

--- a/docs/source/data-structures.rst
+++ b/docs/source/data-structures.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 .. _data structures:
 
 Data Structures

--- a/docs/source/data-structures.rst
+++ b/docs/source/data-structures.rst
@@ -14,6 +14,8 @@ Data Structures
     np.random.seed(123456)
     np.set_printoptions(threshold=10)
 
+    %xmode minimal
+
 .. note::
 
     This page builds on the information given in xarray's main page on

--- a/docs/source/hierarchical-data.rst
+++ b/docs/source/hierarchical-data.rst
@@ -14,6 +14,7 @@ Working With Hierarchical Data
     np.random.seed(123456)
     np.set_printoptions(threshold=10)
 
+    %xmode minimal
 
 Why Hierarchical Data?
 ----------------------

--- a/docs/source/hierarchical-data.rst
+++ b/docs/source/hierarchical-data.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 .. _hierarchical-data:
 
 Working With Hierarchical Data

--- a/docs/source/hierarchical-data.rst
+++ b/docs/source/hierarchical-data.rst
@@ -33,7 +33,7 @@ Examples of data which one might want organise in a grouped or hierarchical mann
 
 or even any combination of the above.
 
-Often datasets like this cannot easily fit into a single ``xarray.Dataset`` object,
+Often datasets like this cannot easily fit into a single :py:class:`xarray.Dataset` object,
 or are more usefully thought of as groups of related ``xarray.Dataset`` objects.
 For this purpose we provide the :py:class:`DataTree` class.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 Datatree
 ========
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 ============
 Installation
 ============

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 .. _io:
 
 Reading and Writing Files

--- a/docs/source/quick-overview.rst
+++ b/docs/source/quick-overview.rst
@@ -7,8 +7,8 @@ Quick overview
 DataTrees
 ---------
 
-:py:class:`DataTree` is a tree-like container of ``DataArray`` objects, organised into multiple mutually alignable groups.
-You can think of it like a (recursive) ``dict`` of ``Dataset`` objects.
+:py:class:`DataTree` is a tree-like container of :py:class:`xarray.DataArray` objects, organised into multiple mutually alignable groups.
+You can think of it like a (recursive) ``dict`` of :py:class:`xarray.Dataset` objects.
 
 Let's first make some example xarray datasets (following on from xarray's
 `quick overview <https://docs.xarray.dev/en/stable/getting-started-guide/quick-overview.html>`_ page):

--- a/docs/source/quick-overview.rst
+++ b/docs/source/quick-overview.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 ##############
 Quick overview
 ##############

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -1,4 +1,5 @@
 .. currentmodule:: datatree
+
 .. _terminology:
 
 This page extends `xarray's page on terminology <https://docs.xarray.dev/en/stable/user-guide/terminology.html>`_.

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: datatree
+
 ========
 Tutorial
 ========

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -50,6 +50,8 @@ Bug fixes
 
 - Fix bug with :py:meth:`DataTree.relative_to` method (:issue:`133`, :pull:`160`).
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- Fix links to API docs in all documentation (:pull:`183`).
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Attempt to fix broken code links in docs, specified by ``:py:class:`DataTree` ``

Doesn't work yet though, and I don't know why :confused: 

- [x] Closes part of Joe's comment https://github.com/xarray-contrib/datatree/issues/61#issuecomment-1371519443
- [ ] ~~Tests added~~
- [x] Passes `pre-commit run --all-files`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [ ] Changes are summarized in `docs/source/whats-new.rst`
