### PR TITLE
Implement dask-specific methods

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -1348,7 +1348,6 @@ class DataTree(
     def plot(self):
         raise NotImplementedError
 
-
     def load(self: T_DataTree, **kwargs) -> T_DataTree:
         """Manually trigger loading of the data referenced by this collection.
         
@@ -1381,7 +1380,6 @@ class DataTree(
         }
         return DataTree.from_dict(new_datatree_dict)
 
-
     def compute(self: T_DataTree, **kwargs) -> T_DataTree:
         """Manually trigger loading of the data referenced by this collection
         and return a new DataTree. The original is left unaltered.
@@ -1402,7 +1400,6 @@ class DataTree(
         """
         new = self.copy(deep=False)
         return new.load(**kwargs)
-
 
     def persist(self: T_DataTree, **kwargs) -> T_DataTree:
         """Trigger computation in constituent dask arrays.
@@ -1427,6 +1424,33 @@ class DataTree(
             for node in self.subtree
         }
         return DataTree.from_dict(new_datatree_dict)
+
+    def __dask_tokenize__(self):
+        raise NotImplementedError
+
+    def __dask_graph__(self):
+        raise NotImplementedError
+
+    def __dask_keys__(self):
+        raise NotImplementedError
+
+    def __dask_layers__(self):
+        raise NotImplementedError
+
+    @property
+    def __dask_optimize__(self):
+        raise NotImplementedError
+
+    @property
+    def __dask_scheduler__(self):
+        raise NotImplementedError
+
+    def __dask_postcompute__(self):
+        raise NotImplementedError
+
+    def __dask_postpersist__(self):
+        raise NotImplementedError
+
 
 
         


### PR DESCRIPTION
This is an initial implementation of the feature requested in #97. 

The first implementation here very closely follows the implementation of these methods by `xarray.Dataset`. For the majority of the methods, this should work fine; we iterate over all the nodes in our tree, starting at the root, and perform the necessary `dask.collections` API operation. However, `__dask_post{compute,persist}__` is a bit more complicated; some additional testing is required to ensure that we're appropriately applying the available support utilities to re-construct our final `DataTree` without any superfluous work.

- [ ] Closes #97
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] New functions/methods are listed in `api.rst`
- [ ] Changes are summarized in `docs/source/whats-new.rst`
