### PR TITLE
update the badge route

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ At this point in development, user feedback is critical to help us create someth
 Please raise any thoughts, issues, suggestions or bugs, no matter how small or large, on the [github issue tracker](https://github.com/xarray-contrib/datatree/issues).
 
 
-[github-ci-badge]: https://img.shields.io/github/workflow/status/xarray-contrib/datatree/CI?label=CI&logo=github
+[github-ci-badge]: https://img.shields.io/github/workflow/status/xarray-contrib/datatree/main.yaml?branch=main&label=CI&logo=github
 [github-ci-link]: https://github.com/xarray-contrib/datatree/actions?query=workflow%3ACI
 [codecov-badge]: https://img.shields.io/codecov/c/github/xarray-contrib/datatree.svg?logo=codecov
 [codecov-link]: https://codecov.io/gh/xarray-contrib/datatree

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ At this point in development, user feedback is critical to help us create someth
 Please raise any thoughts, issues, suggestions or bugs, no matter how small or large, on the [github issue tracker](https://github.com/xarray-contrib/datatree/issues).
 
 
-[github-ci-badge]: https://img.shields.io/github/workflow/status/xarray-contrib/datatree/main.yaml?branch=main&label=CI&logo=github
+[github-ci-badge]: https://img.shields.io/github/actions/workflow/status/xarray-contrib/datatree/main.yaml?branch=main&label=CI&logo=github
 [github-ci-link]: https://github.com/xarray-contrib/datatree/actions?query=workflow%3ACI
 [codecov-badge]: https://img.shields.io/codecov/c/github/xarray-contrib/datatree.svg?logo=codecov
 [codecov-link]: https://codecov.io/gh/xarray-contrib/datatree


### PR DESCRIPTION
There's been a [breaking change](https://github.com/badges/shields/issues/8671) to the workflow badge routes, so we have to follow that. This also hard-codes the branch to `main`, which I think is more predictable than
> look […] for builds on the default branch and fall back to the latest build on any branch or ref if none are found on the default branch.