### PR TITLE
allow `DataTree` objects as root node in `from_dict`

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -991,7 +991,10 @@ class DataTree(
 
         # First create the root node
         root_data = d.pop("/", None)
-        obj = cls(name=name, data=root_data, parent=None, children=None)
+        if not isinstance(root_data, cls):
+            obj = cls(name=name, data=root_data, parent=None, children=None)
+        else:
+            obj = root_data.copy()
 
         if d:
             # Populate tree with children determined from data_objects mapping

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -499,6 +499,13 @@ class TestTreeFromDict:
 
         dtt.assert_identical(actual, expected)
 
+    def test_datatree_values_root(self):
+        expected = DataTree(data=xr.Dataset({"a": 1}))
+
+        actual = DataTree.from_dict({"/": expected})
+
+        dtt.assert_identical(actual, expected)
+
     def test_roundtrip(self, simple_datatree):
         dt = simple_datatree
         roundtrip = DataTree.from_dict(dt.to_dict())

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -44,6 +44,8 @@ Bug fixes
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - copy subtrees without creating ancestor nodes (:pull:`201`)
   By `Justus Magin <https://github.com/keewis>`_.
+- allow `DataTree` objects as root node in `from_dict` (:pull:`221`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
- [x] follow-up to #159
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are summarized in `docs/source/whats-new.rst`