### PR TITLE
FIX: Fix bug with nodepath python 3.12 issues

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
           python -m pytest --cov=./ --cov-report=xml --verbose
 
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.4
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,7 +65,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
 

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -1,7 +1,7 @@
 import pytest
 
 from datatree.iterators import LevelOrderIter, PreOrderIter
-from datatree.treenode import InvalidTreeError, NamedNode, TreeNode
+from datatree.treenode import InvalidTreeError, NamedNode, NodePath, TreeNode
 
 
 class TestFamilyTree:
@@ -369,3 +369,9 @@ class TestRenderTree:
         ]
         for expected_node, printed_node in zip(expected_nodes, printout.splitlines()):
             assert expected_node in printed_node
+
+
+def test_nodepath():
+    path = NodePath("/Mary")
+    assert path.root == "/"
+    assert path.stem == "Mary"

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -29,6 +29,7 @@ class NotFoundInTreeError(ValueError):
 
 
 class NodePath(PurePosixPath):
+    """Represents a path from one node to another within a tree."""
     def __init__(self, *pathsegments):
         if sys.version_info >= (3, 12):
             super().__init__(*pathsegments)
@@ -41,7 +42,7 @@ class NodePath(PurePosixPath):
             raise ValueError(
                 'Root of NodePath can only be either "/" or "", with "" meaning the path is relative.'
             )
-
+        # TODO should we also forbid suffixes to avoid node names with dots in them?
 
 Tree = TypeVar("Tree", bound="TreeNode")
 

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections import OrderedDict
 from pathlib import PurePosixPath
 from typing import (
@@ -28,22 +29,18 @@ class NotFoundInTreeError(ValueError):
 
 
 class NodePath(PurePosixPath):
-    """Represents a path from one node to another within a tree."""
-
-    def __new__(cls, *args: str | "NodePath") -> "NodePath":
-        obj = super().__new__(cls, *args)
-
-        if obj.drive:
+    def __init__(self, *pathsegments):
+        if sys.version_info >= (3, 12):
+            super().__init__(*pathsegments)
+        else:
+            super().__new__(PurePosixPath, *pathsegments)
+        if self.drive:
             raise ValueError("NodePaths cannot have drives")
 
-        if obj.root not in ["/", ""]:
+        if self.root not in ["/", ""]:
             raise ValueError(
                 'Root of NodePath can only be either "/" or "", with "" meaning the path is relative.'
             )
-
-        # TODO should we also forbid suffixes to avoid node names with dots in them?
-
-        return obj
 
 
 Tree = TypeVar("Tree", bound="TreeNode")

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -32,6 +32,9 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
+- Ensure nodepath class is compatible with python 3.12 (:pull:`260`)
+  By `Max Grover <https://github.com/mgrover1>`_.
+
 Documentation
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
This fixes a subclassing issue with the NodePath class currently implemented in datatree. This also adds a test for the NodePath class, and adds tests for python 3.12. A check for python version is used to ensure backwards compatibility.

- [x] Closes #257 
- [x] Closes #259 
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] New functions/methods are listed in `api.rst`
- [x] Changes are summarized in `docs/source/whats-new.rst`
