### PR TITLE
Map over only data nodes, ignoring attrs

### DIFF
--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -109,8 +109,8 @@ def map_over_subtree(func: Callable) -> Callable:
 
     Applies a function to every dataset in one or more subtrees, returning new trees which store the results.
 
-    The function will be applied to any non-empty dataset stored in any of the nodes in the trees. The returned trees
-    will have the same structure as the supplied trees.
+    The function will be applied to any data-containing dataset stored in any of the nodes in the trees. The returned
+    trees will have the same structure as the supplied trees.
 
     `func` needs to return one Datasets, DataArrays, or None in order to be able to rebuild the subtrees after
     mapping, as each result will be assigned to its respective node of a new tree via `DataTree.__setitem__`. Any
@@ -206,7 +206,7 @@ def map_over_subtree(func: Callable) -> Callable:
             # Now we can call func on the data in this particular set of corresponding nodes
             results = (
                 func(*node_args_as_datasets, **node_kwargs_as_datasets)
-                if not node_of_first_tree.is_empty
+                if node_of_first_tree.has_data
                 else None
             )
 

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -605,9 +605,9 @@ class TestAccess:
 
     def test_operation_with_attrs_but_no_data(self):
         # tests bug from xarray-datatree GH262
-        xs = xr.Dataset({'testvar': xr.DataArray(np.ones((2,3)))})
-        dt = DataTree.from_dict({'node1': xs, 'node2': xs})
-        dt.attrs['test_key'] = 1  # sel works fine without this line
+        xs = xr.Dataset({"testvar": xr.DataArray(np.ones((2, 3)))})
+        dt = DataTree.from_dict({"node1": xs, "node2": xs})
+        dt.attrs["test_key"] = 1  # sel works fine without this line
         dt.sel(dim_0=0)
 
 

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -603,6 +603,13 @@ class TestAccess:
         var_keys = list(dt.variables.keys())
         assert all(var_key in key_completions for var_key in var_keys)
 
+    def test_operation_with_attrs_but_no_data(self):
+        # tests bug from xarray-datatree GH262
+        xs = xr.Dataset({'testvar': xr.DataArray(np.ones((2,3)))})
+        dt = DataTree.from_dict({'node1': xs, 'node2': xs})
+        dt.attrs['test_key'] = 1  # sel works fine without this line
+        dt.sel(dim_0=0)
+
 
 class TestRestructuring:
     def test_drop_nodes(self):

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -259,7 +259,8 @@ class TestMapOverSubTree:
 
         def check_for_data(ds):
             # fails if run on a node that has no data
-            assert len(ds.variables) == 0
+            assert len(ds.variables) != 0
+            return ds
 
         dt.map_over_subtree(check_for_data)
 

--- a/datatree/tests/test_mapping.py
+++ b/datatree/tests/test_mapping.py
@@ -252,6 +252,17 @@ class TestMapOverSubTree:
         result_tree = times_ten(subtree)
         assert_equal(result_tree, expected, from_root=False)
 
+    def test_skip_empty_nodes_with_attrs(self, create_test_datatree):
+        # inspired by xarray-datatree GH262
+        dt = create_test_datatree()
+        dt["set1/set2"].attrs["foo"] = "bar"
+
+        def check_for_data(ds):
+            # fails if run on a node that has no data
+            assert len(ds.variables) == 0
+
+        dt.map_over_subtree(check_for_data)
+
 
 class TestMutableOperations:
     def test_construct_using_type(self):

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -26,6 +26,9 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Nodes containing only attributes but no data are now ignored by :py:func:`map_over_subtree` (:issue:`262`, :pull:`263`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Not totally sure if this is a good idea yet

- [x] Closes #262
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [x] Changes are summarized in `docs/source/whats-new.rst`
