### PR TITLE
Change default write mode of `to_zarr()` to `'w-'`

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -1496,7 +1496,12 @@ class DataTree(
         )
 
     def to_zarr(
-        self, store, mode: str = "w", encoding=None, consolidated: bool = True, **kwargs
+        self,
+        store,
+        mode: str = "w-",
+        encoding=None,
+        consolidated: bool = True,
+        **kwargs,
     ):
         """
         Write datatree contents to a Zarr store.
@@ -1505,7 +1510,7 @@ class DataTree(
         ----------
         store : MutableMapping, str or Path, optional
             Store or path to directory in file system
-        mode : {{"w", "w-", "a", "r+", None}, default: "w"
+        mode : {{"w", "w-", "a", "r+", None}, default: "w-"
             Persistence mode: “w” means create (overwrite if exists); “w-” means create (fail if exists);
             “a” means override existing variables (create if does not exist); “r+” means modify existing
             array values only (raise an error if any metadata or shapes would change). The default mode

--- a/datatree/io.py
+++ b/datatree/io.py
@@ -176,7 +176,7 @@ def _create_empty_zarr_group(store, group, mode):
 def _datatree_to_zarr(
     dt: DataTree,
     store,
-    mode: str = "w",
+    mode: str = "w-",
     encoding=None,
     consolidated: bool = True,
     **kwargs,

--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -1,4 +1,5 @@
 import pytest
+import zarr.errors
 
 from datatree.io import open_datatree
 from datatree.testing import assert_equal
@@ -109,3 +110,11 @@ class TestIO:
         with pytest.warns(RuntimeWarning, match="consolidated"):
             roundtrip_dt = open_datatree(filepath, engine="zarr")
         assert_equal(original_dt, roundtrip_dt)
+
+    @requires_zarr
+    def test_to_zarr_default_write_mode(self, tmpdir, simple_datatree):
+        simple_datatree.to_zarr(tmpdir)
+
+        # with default settings, to_zarr should not overwrite an existing dir
+        with pytest.raises(zarr.errors.ContainsGroupError):
+            simple_datatree.to_zarr(tmpdir)

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -26,6 +26,10 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Change default write mode of :py:meth:`DataTree.to_zarr` to ``'w-'`` to match ``xarray``
+  default and prevent accidental directory overwrites. (:issue:`274`, :pull:`275`)
+  By `Sam Levang <https://github.com/slevang>`_.
+
 Deprecations
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #274
- [x] Passes `pre-commit run --all-files`
- [x] Changes are summarized in `docs/source/whats-new.rst`
- [x] Regression test added
