### PR TITLE
Allow passing os.PathLike as an alternative to strings to represent node paths

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -62,6 +62,8 @@ if TYPE_CHECKING:
     from xarray.core.merge import CoercibleValue
     from xarray.core.types import ErrorOptions
 
+    from datatree.treenode import T_PathLike
+
 # """
 # DEVELOPERS' NOTE
 # ----------------
@@ -74,9 +76,6 @@ if TYPE_CHECKING:
 # (normally because they (a) only call dataset properties and (b) don't return a dataset that should be nested into a new
 # tree) and some will get overridden by the class definition of DataTree.
 # """
-
-
-T_Path = Union[str, NodePath]
 
 
 def _coerce_to_dataset(data: Dataset | DataArray | None) -> Dataset:
@@ -848,7 +847,7 @@ class DataTree(
         else:
             return default
 
-    def __getitem__(self: DataTree, key: str) -> DataTree | DataArray:
+    def __getitem__(self: DataTree, key: T_PathLike) -> DataTree | DataArray:
         """
         Access child nodes, variables, or coordinates stored anywhere in this tree.
 
@@ -903,7 +902,7 @@ class DataTree(
 
     def __setitem__(
         self,
-        key: str,
+        key: T_PathLike,
         value: Any,
     ) -> None:
         """
@@ -1034,7 +1033,7 @@ class DataTree(
     @classmethod
     def from_dict(
         cls,
-        d: MutableMapping[str, Dataset | DataArray | DataTree | None],
+        d: MutableMapping[T_PathLike, Dataset | DataArray | DataTree | None],
         name: Optional[str] = None,
     ) -> DataTree:
         """
@@ -1442,7 +1441,7 @@ class DataTree(
         """Merge all the leaves of a second DataTree into this one."""
         raise NotImplementedError
 
-    def merge_child_nodes(self, *paths, new_path: T_Path) -> DataTree:
+    def merge_child_nodes(self, *paths, new_path: T_PathLike) -> DataTree:
         """Merge a set of child nodes into a single new node."""
         raise NotImplementedError
 

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -4,7 +4,7 @@ import functools
 import sys
 from itertools import repeat
 from textwrap import dedent
-from typing import TYPE_CHECKING, Callable, Tuple
+from typing import TYPE_CHECKING, Callable, Tuple, Union
 
 from xarray import DataArray, Dataset
 
@@ -225,7 +225,7 @@ def map_over_subtree(func: Callable) -> Callable:
         original_root_path = first_tree.path
         result_trees = []
         for i in range(num_return_values):
-            out_tree_contents = {}
+            out_tree_contents: dict[str, Union[None, Dataset]] = {}
             for n in first_tree.subtree:
                 p = n.path
                 if p in out_data_objects.keys():

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -17,7 +17,11 @@ from typing import (
 from xarray.core.utils import Frozen, is_dict_like
 
 if TYPE_CHECKING:
+    from os import PathLike
+
     from xarray.core.types import T_DataArray
+
+    T_PathLike = Union[str, PathLike]
 
 
 class InvalidTreeError(Exception):
@@ -419,14 +423,13 @@ class TreeNode(Generic[Tree]):
 
     # TODO `._walk` method to be called by both `_get_item` and `_set_item`
 
-    def _get_item(self: Tree, path: str | NodePath) -> Union[Tree, T_DataArray]:
+    def _get_item(self: Tree, path: T_PathLike) -> Union[Tree, T_DataArray]:
         """
         Returns the object lying at the given path.
 
         Raises a KeyError if there is no object at the given path.
         """
-        if isinstance(path, str):
-            path = NodePath(path)
+        path = NodePath(path)
 
         if path.root:
             current_node = self.root
@@ -461,7 +464,7 @@ class TreeNode(Generic[Tree]):
 
     def _set_item(
         self: Tree,
-        path: str | NodePath,
+        path: T_PathLike,
         item: Union[Tree, T_DataArray],
         new_nodes_along_path: bool = False,
         allow_overwrite: bool = True,
@@ -487,8 +490,7 @@ class TreeNode(Generic[Tree]):
             If node cannot be reached, and new_nodes_along_path=False.
             Or if a node already exists at the specified path, and allow_overwrite=False.
         """
-        if isinstance(path, str):
-            path = NodePath(path)
+        path = NodePath(path)
 
         if not path.name:
             raise ValueError("Can't set an item under a path which has no name")

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -23,6 +23,9 @@ v0.0.14 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Allow passing :py:class:`os.PathLike` objects as paths to nodes in addition to strings. (:pull:`282`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Broadens the types that getitem and setitem methods accept to include anything that follows the `os.PathLike` protocol.

It's possible there are some additional edge cases here that we should forbid, such as passing a Windows-style path.

- [x] Closes part of #281
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [x] Changes are summarized in `docs/source/whats-new.rst`
