### PR TITLE
DataTree.lineage should be renamed to .parents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # version
 _version.py
+
+# Ignore vscode specific settings
+.vscode/

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -282,7 +282,7 @@ def _handle_errors_with_path_context(path):
 def add_note(err: BaseException, msg: str) -> None:
     # TODO: remove once python 3.10 can be dropped
     if sys.version_info < (3, 11):
-        err.__notes__ = getattr(err, "__notes__", []) + [msg]
+        err.__notes__ = getattr(err, "__notes__", []) + [msg]  # type: ignore
     else:
         err.add_note(msg)
 

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -292,7 +292,7 @@ class TestAncestry:
 
     def test_iter_lineage(self):
         _, leaf = create_test_tree()
-        assert tuple(leaf.iter_lineage()) == tuple(leaf.iter_parents())
+        assert tuple(leaf.iter_lineage()) == tuple(leaf.parents)
 
     def test_ancestors(self):
         _, leaf = create_test_tree()

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -286,6 +286,14 @@ class TestAncestry:
         for node, expected_name in zip(parents, expected):
             assert node.name == expected_name
 
+    def test_lineage(self):
+        _, leaf = create_test_tree()
+        assert leaf.lineage == leaf.parents
+
+    def test_iter_lineage(self):
+        _, leaf = create_test_tree()
+        assert tuple(leaf.iter_lineage()) == tuple(leaf.iter_parents())
+
     def test_ancestors(self):
         _, leaf = create_test_tree()
         ancestors = leaf.ancestors

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -96,7 +96,7 @@ class TestFamilyTree:
         vito = TreeNode(children={"Michael": michael})
         assert tony.root is vito
         assert tony.parents == (michael, vito)
-        assert tony.ancestors == (vito, michael)
+        assert tony.ancestors == (vito, michael, tony)
 
 
 class TestGetNodes:

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -281,18 +281,13 @@ class TestIterators:
 class TestAncestry:
     def test_parents(self):
         _, leaf = create_test_tree()
-        parents = leaf.parents
-        expected = ["f", "e", "b", "a"]
-        for node, expected_name in zip(parents, expected):
-            assert node.name == expected_name
+        expected = ["e", "b", "a"]
+        assert [node.name for node in leaf.parents] == expected
 
     def test_lineage(self):
         _, leaf = create_test_tree()
-        assert leaf.lineage == leaf.parents
-
-    def test_iter_lineage(self):
-        _, leaf = create_test_tree()
-        assert tuple(leaf.iter_lineage()) == tuple(leaf.parents)
+        expected = ["f", "e", "b", "a"]
+        assert [node.name for node in leaf.lineage] == expected
 
     def test_ancestors(self):
         _, leaf = create_test_tree()

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -95,8 +95,8 @@ class TestFamilyTree:
         michael = TreeNode(children={"Tony": tony})
         vito = TreeNode(children={"Michael": michael})
         assert tony.root is vito
-        assert tony.parents == (tony, michael, vito)
-        assert tony.ancestors == (vito, michael, tony)
+        assert tony.parents == (michael, vito)
+        assert tony.ancestors == (vito, michael)
 
 
 class TestGetNodes:

--- a/datatree/tests/test_treenode.py
+++ b/datatree/tests/test_treenode.py
@@ -95,7 +95,7 @@ class TestFamilyTree:
         michael = TreeNode(children={"Tony": tony})
         vito = TreeNode(children={"Michael": michael})
         assert tony.root is vito
-        assert tony.lineage == (tony, michael, vito)
+        assert tony.parents == (tony, michael, vito)
         assert tony.ancestors == (vito, michael, tony)
 
 
@@ -279,11 +279,11 @@ class TestIterators:
 
 
 class TestAncestry:
-    def test_lineage(self):
+    def test_parents(self):
         _, leaf = create_test_tree()
-        lineage = leaf.lineage
+        parents = leaf.parents
         expected = ["f", "e", "b", "a"]
-        for node, expected_name in zip(lineage, expected):
+        for node, expected_name in zip(parents, expected):
             assert node.name == expected_name
 
     def test_ancestors(self):

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -243,10 +243,33 @@ class TreeNode(Generic[Tree]):
             yield node
             node = node.parent
 
+    def iter_lineage(self: Tree) -> Iterator[Tree]:
+        """Iterate up the tree, starting from the current node."""
+        from warnings import warn
+
+        warn(
+            "`iter_lineage` has been deprecated, and in the future will raise an error."
+            "Please use `iter_parents` from now on.",
+            DeprecationWarning,
+        )
+        yield from self.iter_parents()
+
     @property
     def parents(self: Tree) -> Tuple[Tree, ...]:
         """All parent nodes and their parent nodes, starting with the closest."""
         return tuple(self.iter_parents())
+
+    @property
+    def lineage(self: Tree) -> Tuple[Tree, ...]:
+        """All parent nodes and their parent nodes, starting with the closest."""
+        from warnings import warn
+
+        warn(
+            "`lineage` has been deprecated, and in the future will raise an error."
+            "Please use `parents` from now on.",
+            DeprecationWarning,
+        )
+        return self.parents
 
     @property
     def ancestors(self: Tree) -> Tuple[Tree, ...]:

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -634,7 +634,7 @@ class NamedNode(TreeNode, Generic[Tree]):
             )
 
         this_path = NodePath(self.path)
-        if other.path in list(parent.path for parent in self.parents):
+        if other.path in list(parent.path for parent in (self, *self.parents)):
             return str(this_path.relative_to(other.path))
         else:
             common_ancestor = self.find_common_ancestor(other)

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -121,8 +121,8 @@ class TreeNode(Generic[Tree]):
                 )
 
     def _is_descendant_of(self, node: Tree) -> bool:
-        _self, *lineage = list(node.lineage)
-        return any(n is self for n in lineage)
+        _self, *parents = list(node.parents)
+        return any(n is self for n in parents)
 
     def _detach(self, parent: Tree | None) -> None:
         if parent is not None:
@@ -236,7 +236,7 @@ class TreeNode(Generic[Tree]):
         """Method call after attaching `children`."""
         pass
 
-    def iter_lineage(self: Tree) -> Iterator[Tree]:
+    def iter_parents(self: Tree) -> Iterator[Tree]:
         """Iterate up the tree, starting from the current node."""
         node: Tree | None = self
         while node is not None:
@@ -244,9 +244,9 @@ class TreeNode(Generic[Tree]):
             node = node.parent
 
     @property
-    def lineage(self: Tree) -> Tuple[Tree, ...]:
+    def parents(self: Tree) -> Tuple[Tree, ...]:
         """All parent nodes and their parent nodes, starting with the closest."""
-        return tuple(self.iter_lineage())
+        return tuple(self.iter_parents())
 
     @property
     def ancestors(self: Tree) -> Tuple[Tree, ...]:
@@ -254,7 +254,7 @@ class TreeNode(Generic[Tree]):
         if self.parent is None:
             return (self,)
         else:
-            ancestors = tuple(reversed(list(self.lineage)))
+            ancestors = tuple(reversed(list(self.parents)))
             return ancestors
 
     @property
@@ -608,7 +608,7 @@ class NamedNode(TreeNode, Generic[Tree]):
             )
 
         this_path = NodePath(self.path)
-        if other.path in list(ancestor.path for ancestor in self.lineage):
+        if other.path in list(ancestor.path for ancestor in self.parents):
             return str(this_path.relative_to(other.path))
         else:
             common_ancestor = self.find_common_ancestor(other)
@@ -624,7 +624,7 @@ class NamedNode(TreeNode, Generic[Tree]):
         Raise ValueError if they are not in the same tree.
         """
         common_ancestor = None
-        for node in other.iter_lineage():
+        for node in other.iter_parents():
             if node.path in [ancestor.path for ancestor in self.ancestors]:
                 common_ancestor = node
                 break
@@ -648,7 +648,7 @@ class NamedNode(TreeNode, Generic[Tree]):
                 "Cannot find relative path to ancestor because given node is not an ancestor of this node"
             )
 
-        lineage_paths = list(ancestor.path for ancestor in self.lineage)
-        generation_gap = list(lineage_paths).index(ancestor.path)
+        parents_paths = list(ancestor.path for ancestor in self.parents)
+        generation_gap = list(parents_paths).index(ancestor.path)
         path_upwards = "../" * generation_gap if generation_gap > 0 else "/"
         return NodePath(path_upwards)

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -273,6 +273,14 @@ class TreeNode(Generic[Tree]):
     @property
     def ancestors(self: Tree) -> Tuple[Tree, ...]:
         """All parent nodes and their parent nodes, starting with the most distant."""
+
+        from warnings import warn
+
+        warn(
+            "`ancestors` has been deprecated, and in the future will raise an error."
+            "Please use `parents`. Example: `tuple(reversed(node.parents))`",
+            DeprecationWarning,
+        )
         return tuple(reversed(self.parents))
 
     @property
@@ -369,7 +377,7 @@ class TreeNode(Generic[Tree]):
         depth
         width
         """
-        return len(self.ancestors)
+        return len(self.parents)
 
     @property
     def depth(self: Tree) -> int:
@@ -609,7 +617,7 @@ class NamedNode(TreeNode, Generic[Tree]):
         if self.is_root:
             return "/"
         else:
-            root, *ancestors = self.ancestors
+            root, *ancestors = tuple(reversed(self.parents))
             # don't include name of root because (a) root might not have a name & (b) we want path relative to root.
             names = [*(node.name for node in ancestors), self.name]
             return "/" + "/".join(names)
@@ -660,7 +668,7 @@ class NamedNode(TreeNode, Generic[Tree]):
             raise NotFoundInTreeError(
                 "Cannot find relative path to ancestor because nodes do not lie within the same tree"
             )
-        if ancestor.path not in list(a.path for a in (*self.ancestors, self)):
+        if ancestor.path not in list(a.path for a in (self, *self.parents)):
             raise NotFoundInTreeError(
                 "Cannot find relative path to ancestor because given node is not an ancestor of this node"
             )

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -281,7 +281,7 @@ class TreeNode(Generic[Tree]):
             "Please use `parents`. Example: `tuple(reversed(node.parents))`",
             DeprecationWarning,
         )
-        return tuple(reversed(self.parents))
+        return tuple((*reversed(self.parents), self))
 
     @property
     def root(self: Tree) -> Tree:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -37,6 +37,7 @@ Attributes relating to the recursive tree-like structure of a ``DataTree``.
    DataTree.subtree
    DataTree.descendants
    DataTree.siblings
+   DataTree.lineage
    DataTree.parents
    DataTree.ancestors
    DataTree.groups
@@ -93,6 +94,7 @@ For manipulating, traversing, navigating, or mapping over the tree structure.
    DataTree.orphan
    DataTree.same_tree
    DataTree.relative_to
+   DataTree.iter_lineage
    DataTree.iter_parents
    DataTree.find_common_ancestor
    DataTree.map_over_subtree

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -37,7 +37,7 @@ Attributes relating to the recursive tree-like structure of a ``DataTree``.
    DataTree.subtree
    DataTree.descendants
    DataTree.siblings
-   DataTree.lineage
+   DataTree.parents
    DataTree.ancestors
    DataTree.groups
 
@@ -93,7 +93,7 @@ For manipulating, traversing, navigating, or mapping over the tree structure.
    DataTree.orphan
    DataTree.same_tree
    DataTree.relative_to
-   DataTree.iter_lineage
+   DataTree.iter_parents
    DataTree.find_common_ancestor
    DataTree.map_over_subtree
    map_over_subtree

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -95,7 +95,6 @@ For manipulating, traversing, navigating, or mapping over the tree structure.
    DataTree.same_tree
    DataTree.relative_to
    DataTree.iter_lineage
-   DataTree.iter_parents
    DataTree.find_common_ancestor
    DataTree.map_over_subtree
    map_over_subtree

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -26,6 +26,8 @@ New Features
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
+- Renamed `DataTree.lineage` to `DataTree.parents` to match `pathlib` vocabulary
+  (:issue:`283`, :pull:`286`)
 - Minimum required version of xarray is now 2023.12.0, i.e. the latest version.
   This is required to prevent recent changes to xarray's internals from breaking datatree.
   (:issue:`293`, :pull:`294`)

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -41,6 +41,7 @@ Deprecations
 
 - Renamed `DataTree.lineage` to `DataTree.parents` to match `pathlib` vocabulary
   (:issue:`283`, :pull:`286`). `lineage` is now deprecated and use of `parents` is encouraged.
+  By `Etienne Schalk <https://github.com/etienneschalk>`_.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -39,6 +39,9 @@ Breaking changes
 Deprecations
 ~~~~~~~~~~~~
 
+- Renamed `DataTree.lineage` to `DataTree.parents` to match `pathlib` vocabulary
+  (:issue:`283`, :pull:`286`). `lineage` is now deprecated and use of `parents` is encouraged.
+
 Bug fixes
 ~~~~~~~~~
 - Keep attributes on nodes containing no data in :py:func:`map_over_subtree`. (:issue:`278`, :pull:`279`)


### PR DESCRIPTION
## Open Points

- [x] (1) Should a deprecation warning be added? Currently, no deprecation warning.
    - Yes
- [x] (2) Should an sub-issue be created from #283, or is the task small enough that it can leave in a Pull Request?
    - No
- [x] (3) Should `lineage` and `iter_lineage` be removed from `api.rst`? 
    - No
    - Reason: See https://github.com/xarray-contrib/datatree/pull/286#issuecomment-1837556861

## Checklist 

- [x] Subtask  `DataTree.lineage should be renamed to .parents` of #283
- [x] Tests added
    - Renamed `test_lineage` to `test_parents`
    - Rewrote `test_lineage` so that it tests that the `lineage` and  `parents` properties are equivalent
    - Wrote `test_iter_lineage` to verify that `iter_lineage` and `iter_parents` yield the same results
- [x] Passes `pre-commit run --all-files`
    - :warning: I had to add a `#type: ignore` comment
- [x] New functions/methods are listed in `api.rst`
    - `lineage` and `iter_lineage` removed (see open point (3))
    - `parents` and `iter_parents` added 
- [x] Changes are summarized in `docs/source/whats-new.rst`
    - In section  "Deprecation"