### PR TITLE
Use napoleon instead of numpydoc (xarray doc alignment), and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 
 # version
 _version.py
+
+.vscode

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -13,8 +13,8 @@ dependencies:
   - sphinx-book-theme >= 0.0.38
   - nbsphinx
   - sphinxcontrib-srclinks
+  - pickleshare
   - pydata-sphinx-theme>=0.4.3
-  - numpydoc
   - ipython
   - h5netcdf
   - zarr

--- a/datatree/mapping.py
+++ b/datatree/mapping.py
@@ -282,7 +282,7 @@ def _handle_errors_with_path_context(path):
 def add_note(err: BaseException, msg: str) -> None:
     # TODO: remove once python 3.10 can be dropped
     if sys.version_info < (3, 11):
-        err.__notes__ = getattr(err, "__notes__", []) + [msg]
+        err.__notes__ = getattr(err, "__notes__", []) + [msg]  # type: ignore[attr-defined]
     else:
         err.add_note(msg)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+# README - docs
+
 ## Build the documentation locally
 
 ```bash
@@ -6,3 +8,7 @@ make clean
 rm -rf source/generated # remove autodoc artefacts, that are not removed by `make clean`
 make html
 ```
+
+## Access the documentation locally
+
+Open `docs/_build/html/index.html` in a web browser

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+## Build the documentation locally
+
+```bash
+cd docs # From project's root
+make clean
+rm -rf source/generated # remove autodoc artefacts, that are not removed by `make clean`
+make html
+```

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -249,9 +249,7 @@ Methods copied from :py:class:`numpy.ndarray` objects, here applying to the data
    DataTree.clip
    DataTree.conj
    DataTree.conjugate
-   DataTree.imag
    DataTree.round
-   DataTree.real
    DataTree.rank
 
 Reshaping and reorganising

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,6 @@ sys.path.insert(0, parent)
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.linkcode",
@@ -57,14 +56,77 @@ extensions = [
 ]
 
 extlinks = {
-    "issue": ("https://github.com/TomNicholas/datatree/issues/%s", "GH#"),
-    "pull": ("https://github.com/TomNicholas/datatree/pull/%s", "GH#"),
+    "issue": ("https://github.com/xarray-contrib/datatree/issues/%s", "GH#%s"),
+    "pull": ("https://github.com/xarray-contrib/datatree/pull/%s", "GH#%s"),
 }
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 
 # Generate the API documentation when building
 autosummary_generate = True
+
+
+# Napoleon configurations
+
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_use_param = False
+napoleon_use_rtype = False
+napoleon_preprocess_types = True
+napoleon_type_aliases = {
+    # general terms
+    "sequence": ":term:`sequence`",
+    "iterable": ":term:`iterable`",
+    "callable": ":py:func:`callable`",
+    "dict_like": ":term:`dict-like <mapping>`",
+    "dict-like": ":term:`dict-like <mapping>`",
+    "path-like": ":term:`path-like <path-like object>`",
+    "mapping": ":term:`mapping`",
+    "file-like": ":term:`file-like <file-like object>`",
+    # special terms
+    # "same type as caller": "*same type as caller*",  # does not work, yet
+    # "same type as values": "*same type as values*",  # does not work, yet
+    # stdlib type aliases
+    "MutableMapping": "~collections.abc.MutableMapping",
+    "sys.stdout": ":obj:`sys.stdout`",
+    "timedelta": "~datetime.timedelta",
+    "string": ":class:`string <str>`",
+    # numpy terms
+    "array_like": ":term:`array_like`",
+    "array-like": ":term:`array-like <array_like>`",
+    "scalar": ":term:`scalar`",
+    "array": ":term:`array`",
+    "hashable": ":term:`hashable <name>`",
+    # matplotlib terms
+    "color-like": ":py:func:`color-like <matplotlib.colors.is_color_like>`",
+    "matplotlib colormap name": ":doc:`matplotlib colormap name <matplotlib:gallery/color/colormap_reference>`",
+    "matplotlib axes object": ":py:class:`matplotlib axes object <matplotlib.axes.Axes>`",
+    "colormap": ":py:class:`colormap <matplotlib.colors.Colormap>`",
+    # objects without namespace: xarray
+    "DataArray": "~xarray.DataArray",
+    "Dataset": "~xarray.Dataset",
+    "Variable": "~xarray.Variable",
+    "DatasetGroupBy": "~xarray.core.groupby.DatasetGroupBy",
+    "DataArrayGroupBy": "~xarray.core.groupby.DataArrayGroupBy",
+    # objects without namespace: numpy
+    "ndarray": "~numpy.ndarray",
+    "MaskedArray": "~numpy.ma.MaskedArray",
+    "dtype": "~numpy.dtype",
+    "ComplexWarning": "~numpy.ComplexWarning",
+    # objects without namespace: pandas
+    "Index": "~pandas.Index",
+    "MultiIndex": "~pandas.MultiIndex",
+    "CategoricalIndex": "~pandas.CategoricalIndex",
+    "TimedeltaIndex": "~pandas.TimedeltaIndex",
+    "DatetimeIndex": "~pandas.DatetimeIndex",
+    "Series": "~pandas.Series",
+    "DataFrame": "~pandas.DataFrame",
+    "Categorical": "~pandas.Categorical",
+    "Path": "~~pathlib.Path",
+    # objects with abbreviated namespace (from pandas)
+    "pd.Index": "~pandas.Index",
+    "pd.NaT": "~pandas.NaT",
+}
 
 # The suffix of source filenames.
 source_suffix = ".rst"
@@ -176,11 +238,6 @@ html_theme_options = {
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
 # html_favicon = None
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -50,7 +50,6 @@ Please raise any thoughts, issues, suggestions or bugs, no matter how small or l
    Reading and Writing Files <io>
    API Reference <api>
    Terminology <terminology>
-   How do I ... <howdoi>
    Contributing Guide <contributing>
    What's New <whats-new>
    GitHub repository <https://github.com/xarray-contrib/datatree>

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -44,6 +44,9 @@ Bug fixes
 
 Documentation
 ~~~~~~~~~~~~~
+- Use ``napoleon`` instead of ``numpydoc`` to align with xarray documentation
+  (:issue:`284`, :pull:`298`).
+  By `Etienne Schalk <https://github.com/etienneschalk>`_.
 
 Internal Changes
 ~~~~~~~~~~~~~~~~

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -365,7 +365,7 @@ Breaking changes
 - Removes the option to delete all data in a node by assigning None to the node (in favour of deleting data by replacing
   the node's ``.ds`` attribute with an empty Dataset), or to create a new empty node in the same way (in favour of
   assigning an empty DataTree object instead).
-- Removes the ability to create a new node by assigning a ``Dataset`` object to ``DataTree.__setitem__`.
+- Removes the ability to create a new node by assigning a ``Dataset`` object to ``DataTree.__setitem__``.
 - Several other minor API changes such as ``.pathstr`` -> ``.path``, and ``from_dict``'s dictionary argument now being
   required. (:pull:`76`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.


### PR DESCRIPTION
## Motives

This issue aims to fix the build fail in #286 

Also, hopefully it can help facilitate the merging into the xarray repo (documentation alignment)

## Checklist 

- [x] Closes #284
- ~~[x] Tests added~~
- [x] Passes `pre-commit run --all-files`
- ~~[x] New functions/methods are listed in `api.rst`~~
- ~~[x] Changes are summarized in `docs/source/whats-new.rst`~~

## Contents

Related to the issue 

- Removed `numpydoc` CI dependency
- Added `pickleshare` CI dependency to fix warnings happening during `make html` locally, that could probably happen in the CI too
- Added a README.md describing how to build, clean and open the documentation
- Removed `DataTree.imag` and `DataTree.real`, they were raising warnings during `make html`
- Fixed the issue and pull extlinks with the new repo's URL
- Copy pasted **all** `napoleon_` prefixed configuration variables in `conf.py`, from xarray repository: See https://github.com/pydata/xarray/blob/492aa076bd1812af71d68dc221312fb9a199d2d3/doc/conf.py#L118
- Removed the `html_static_path` in `conf.py` - it was raising a warning during doc build (unsure about this :question:)
- Removed `howdoi` in index.rst, to fix a warning
- Fixed a code literal in whats new.rst
- 
Misc
- Gitignore `.vscode`
- Added a ignore comment for mypy for existing code so that `pre-commit run --all-files` pass

## Open points

- [x] Should the `html_static_path` in `conf.py` be kept? @TomNicholas 

## Notes

Locally, I `pip install pickleshare` to remove the warnings related to it

There are still warnings, I did not fix them all when I was unsure how to fix them. Here is the console output of the `make html` command:

```
make clean
rm -rf source/generated # remove autodoc artefacts, that are not removed by `make clean`
make html
rm -rf _build/*
sphinx-build -b html -d _build/doctrees   source _build/html
Running Sphinx v6.2.1
make making output directory... done
[autosummary] generating autosummary for: api.rst, contributing.rst, data-structures.rst, hierarchical-data.rst, index.rst, installation.rst, io.rst, quick-overview.rst, terminology.rst, tutorial.rst, whats-new.rst
htm[autosummary] generating autosummary for: /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.__delitem__.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.__getitem__.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.__setitem__.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.all.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.ancestors.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.any.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.argmax.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.argmin.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.argsort.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.assign.rst, ..., /home/my_username/dev/datatree/docs/source/generated/datatree.DataTree.width.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.InvalidTreeError.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.NotFoundInTreeError.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.TreeIsomorphismError.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.map_over_subtree.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.open_datatree.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.register_datatree_accessor.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.testing.assert_equal.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.testing.assert_identical.rst, /home/my_username/dev/datatree/docs/source/generated/datatree.testing.assert_isomorphic.rst
loading intersphinx inventory from https://docs.python.org/3.8/objects.inv...
loading intersphinx inventory from https://numpy.org/doc/stable/objects.inv...
loading intersphinx inventory from https://xarray.pydata.org/en/stable/objects.inv...
lintersphinx inventory has moved: https://xarray.pydata.org/en/stable/objects.inv -> https://docs.xarray.dev/en/stable/objects.inv
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 11 source files that are out of date
updating environment: [new config] 157 added, 0 changed, 0 removed
reading sources... [100%] whats-new                                                                                                                                         
/home/my_username/dev/datatree/docs/source/data-structures.rst:6: WARNING: Duplicate explicit target name: "data structures".
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] whats-new                                                                                                                                          
/home/my_username/.pyenv/versions/3.10.12/envs/datatree-dev/lib/python3.10/site-packages/xarray/core/dataset.py:docstring of xarray.core.dataset.Dataset.interp:49: WARNING: unknown document: 'xarray-tutorial:fundamentals/02.2_manipulating_dimensions'
/home/my_username/.pyenv/versions/3.10.12/envs/datatree-dev/lib/python3.10/site-packages/xarray/core/dataset.py:docstring of xarray.core.dataset.Dataset.isel:94: WARNING: unknown document: 'xarray-tutorial:intermediate/indexing/indexing'
/home/my_username/.pyenv/versions/3.10.12/envs/datatree-dev/lib/python3.10/site-packages/xarray/core/dataset.py:docstring of xarray.core.dataset.Dataset.isel:96: WARNING: unknown document: 'xarray-tutorial:fundamentals/02.1_indexing_Basic'
/home/my_username/.pyenv/versions/3.10.12/envs/datatree-dev/lib/python3.10/site-packages/xarray/core/dataset.py:docstring of xarray.core.dataset.Dataset.map_blocks:43: WARNING: unknown document: 'xarray-tutorial:advanced/map_blocks/map_blocks'
/home/my_username/.pyenv/versions/3.10.12/envs/datatree-dev/lib/python3.10/site-packages/xarray/core/dataset.py:docstring of xarray.core.dataset.Dataset.sel:52: WARNING: unknown document: 'xarray-tutorial:intermediate/indexing/indexing'
/home/my_username/.pyenv/versions/3.10.12/envs/datatree-dev/lib/python3.10/site-packages/xarray/core/dataset.py:docstring of xarray.core.dataset.Dataset.sel:54: WARNING: unknown document: 'xarray-tutorial:fundamentals/02.1_indexing_Basic'
generating indices... genindex done
copying linked files... 
copying notebooks ... 
highlighting module code... [100%] datatree.treenode                                                                                                                        
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 7 warnings.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
```
