### PR TITLE
Moves Tree Contents so that simpsons data tree in example is defined.

### DIFF
--- a/docs/source/hierarchical-data.rst
+++ b/docs/source/hierarchical-data.rst
@@ -393,6 +393,7 @@ We can use :py:meth:`DataTree.match` for this:
         }
     )
     result = dt.match("*/B")
+    result
 
 We can also subset trees by the contents of the nodes.
 :py:meth:`DataTree.filter` retains only the nodes of a tree that meet a certain condition.

--- a/docs/source/hierarchical-data.rst
+++ b/docs/source/hierarchical-data.rst
@@ -369,25 +369,6 @@ You can see this tree is similar to the ``dt`` object above, except that it is m
 
 (If you want to keep the name of the root node, you will need to add the ``name`` kwarg to :py:class:`from_dict`, i.e. ``DataTree.from_dict(non_empty_nodes, name=dt.root.name)``.)
 
-.. _Tree Contents:
-
-Tree Contents
--------------
-
-Hollow Trees
-~~~~~~~~~~~~
-
-A concept that can sometimes be useful is that of a "Hollow Tree", which means a tree with data stored only at the leaf nodes.
-This is useful because certain useful tree manipulation operations only make sense for hollow trees.
-
-You can check if a tree is a hollow tree by using the :py:meth:`~DataTree.is_hollow` property.
-We can see that the Simpson's family is not hollow because the data variable ``"age"`` is present at some nodes which
-have children (i.e. Abe and Homer).
-
-.. ipython:: python
-
-    simpsons.is_hollow
-
 .. _manipulating trees:
 
 Manipulating Trees
@@ -442,6 +423,25 @@ Now let's filter out the minors:
 The result is a new tree, containing only the nodes matching the condition.
 
 (Yes, under the hood :py:meth:`~DataTree.filter` is just syntactic sugar for the pattern we showed you in :ref:`iterating over trees` !)
+
+.. _Tree Contents:
+
+Tree Contents
+-------------
+
+Hollow Trees
+~~~~~~~~~~~~
+
+A concept that can sometimes be useful is that of a "Hollow Tree", which means a tree with data stored only at the leaf nodes.
+This is useful because certain useful tree manipulation operations only make sense for hollow trees.
+
+You can check if a tree is a hollow tree by using the :py:class:`~DataTree.is_hollow` property.
+We can see that the Simpson's family is not hollow because the data variable ``"age"`` is present at some nodes which
+have children (i.e. Abe and Homer).
+
+.. ipython:: python
+
+    simpsons.is_hollow
 
 .. _tree computation:
 

--- a/docs/source/hierarchical-data.rst
+++ b/docs/source/hierarchical-data.rst
@@ -600,7 +600,7 @@ Notice that corresponding tree nodes do not need to have the same name or contai
 Arithmetic Between Multiple Trees
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Arithmetic operations like multiplication are binary operations, so as long as we have wo isomorphic trees,
+Arithmetic operations like multiplication are binary operations, so as long as we have two isomorphic trees,
 we can do arithmetic between them.
 
 .. ipython:: python


### PR DESCRIPTION
This is a clone of #300 because I nuked my fork without thinking. 

Since I'm reading the docs and don't know sphinx very well, I saw a problem with the is_hollow description and fixed it.

It may make more sense to have Tree Contents: Hollow Trees above Manipulating Trees: Subsetting Tree Nodes, but the simpsons DataTree is undefined. Rather than create a new tree for this example I just moved it.

In addition to moving it I changed the description from a python method to the py:class so that the rendering didn't include the incorrect parens.

The updated docs after rebuilding show the tree is not hollow rather than NameError: name 'simpsons' is not defined as it did before

New image generated: 

<img width="734" alt="Screenshot 2024-01-18 at 1 50 51 PM" src="https://github.com/xarray-contrib/datatree/assets/479480/1849643a-42fe-4355-982b-bd655f3a19a8">

Also increased clarity of the `dt.match()` operation by printing the result. 
<img width="741" alt="Screenshot 2024-01-18 at 1 49 27 PM" src="https://github.com/xarray-contrib/datatree/assets/479480/7f164c6b-c2e7-44f9-ad67-317b7b4de130">

And fixed a typo. `wo` => `twoj`
