### PR TITLE
Setting node name keeps tree linkage

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -1482,7 +1482,7 @@ class DataTree(
             Note that unlimited_dims may also be set via
             ``dataset.encoding["unlimited_dims"]``.
         kwargs :
-            Additonal keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
+            Additional keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
         """
         from .io import _datatree_to_netcdf
 

--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -1482,7 +1482,7 @@ class DataTree(
             Note that unlimited_dims may also be set via
             ``dataset.encoding["unlimited_dims"]``.
         kwargs :
-            Addional keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
+            Additonal keyword arguments to be passed to ``xarray.Dataset.to_netcdf``
         """
         from .io import _datatree_to_netcdf
 

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -85,6 +85,30 @@ class TestNames:
         assert "childish" in root
         assert list(root.children) == ["childish"]
 
+        # changing name of root
+        root.name = "ginger"
+
+        assert root.name == "ginger"
+
+    def test_setting_node_name_keeps_tree_linkage_and_order(self):
+        root = DataTree.from_dict(
+            {
+                "/one": None,
+                "/two": None,
+                "/three": None,
+            }
+        )
+        assert list(root.children) == ["one", "two", "three"]
+
+        second_child = root["/two"]
+        second_child.name = "second"
+
+        assert second_child.name == "second"
+        assert "second" in root
+
+        # Order was preserved
+        assert list(root.children) == ["one", "second", "three"]
+
 
 class TestPaths:
     def test_path_property(self):

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -109,6 +109,16 @@ class TestNames:
         # Order was preserved
         assert list(root.children) == ["one", "second", "three"]
 
+    def test_setting_node_to_none(self):
+        root = DataTree(name="root")
+        child = DataTree(name="child", parent=root)
+
+        with pytest.raises(
+            ValueError,
+            match=r"a node with a parent cannot have its name set to None",
+        ):
+            child.name = None
+
 
 class TestPaths:
     def test_path_property(self):

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -68,6 +68,23 @@ class TestNames:
         mary = DataTree(children={"Sue": sue})  # noqa
         assert sue.name == "Sue"
 
+    def test_setting_node_name_keeps_tree_linkage(self):
+        root = DataTree(name="root")
+        child = DataTree(name="child", parent=root)
+        grandchild = DataTree(name="grandchild", parent=child)
+
+        assert root.name == "root"
+        assert child.name == "child"
+        assert grandchild.name == "grandchild"
+
+        # changing the name of a child node should correctly update the dict key in
+        # its parent's children
+        child.name = "childish"
+
+        assert child.name == "childish"
+        assert "childish" in root
+        assert list(root.children) == ["childish"]
+
 
 class TestPaths:
     def test_path_property(self):

--- a/datatree/tests/test_formatting.py
+++ b/datatree/tests/test_formatting.py
@@ -108,13 +108,13 @@ class TestDiffFormatting:
         Data in nodes at position '/a' do not match:
 
         Data variables only on the left object:
-            v        int64 1
+            v        int64 8B 1
 
         Data in nodes at position '/a/b' do not match:
 
         Differing data variables:
-        L   w        int64 5
-        R   w        int64 6"""
+        L   w        int64 8B 5
+        R   w        int64 8B 6"""
         )
         actual = diff_tree_repr(dt_1, dt_2, "equals")
         assert actual == expected

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -606,17 +606,18 @@ class NamedNode(TreeNode, Generic[Tree]):
             raise ValueError("node names cannot contain forward slashes")
 
         parent = self._parent
-        if parent is not None:
-            old_name = self._name
-            if old_name is None:
-                raise ValueError("An unnamed node should not have had a parent")
+        if parent is None:
+            self._name = name
+            return
 
-            # Iterate through the ordered dict to preserve the order of children
-            parent.children = OrderedDict(
-                ((k if k != old_name else name, v) for k, v in parent.children.items())
-            )
+        old_name = self._name
+        if old_name is None:
+            raise ValueError("An unnamed node should not have had a parent")
 
-        self._name = name
+        # Iterate through the ordered dict to preserve the order of children
+        parent.children = OrderedDict(
+            ((k if k != old_name else name, v) for k, v in parent.children.items())
+        )
 
     def __str__(self) -> str:
         return f"NamedNode({self.name})" if self.name else "NamedNode()"

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -91,7 +91,7 @@ class TreeNode(Generic[Tree]):
         return self._parent
 
     def _set_parent(
-        self, new_parent: Tree | None, child_name: Optional[str] = None
+        self, new_parent: Tree | None, child_name: str | None = None
     ) -> None:
         # TODO is it possible to refactor in a way that removes this private method?
 
@@ -601,7 +601,10 @@ class NamedNode(TreeNode, Generic[Tree]):
                 raise TypeError("node name must be a string or None")
             if "/" in name:
                 raise ValueError("node names cannot contain forward slashes")
+        parent = self._parent
+        self.orphan()
         self._name = name
+        self._set_parent(parent, name)
 
     def __str__(self) -> str:
         return f"NamedNode({self.name})" if self.name else "NamedNode()"
@@ -609,7 +612,7 @@ class NamedNode(TreeNode, Generic[Tree]):
     def _post_attach(self: NamedNode, parent: NamedNode) -> None:
         """Ensures child has name attribute corresponding to key under which it has been stored."""
         key = next(k for k, v in parent.children.items() if v is self)
-        self.name = key
+        self._name = key
 
     @property
     def path(self) -> str:

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -596,25 +596,25 @@ class NamedNode(TreeNode, Generic[Tree]):
 
     @name.setter
     def name(self, name: str | None) -> None:
-        if name is not None:
-            if not isinstance(name, str):
-                raise TypeError("node name must be a string or None")
-            if "/" in name:
-                raise ValueError("node names cannot contain forward slashes")
+        if name is None:
+            self._name = None
+            return
 
-            parent = self._parent
-            if parent is not None:
-                old_name = self._name
-                if old_name is None:
-                    raise ValueError("An unnamed node should not have had a parent")
+        if not isinstance(name, str):
+            raise TypeError("node name must be a string or None")
+        if "/" in name:
+            raise ValueError("node names cannot contain forward slashes")
 
-                # To preserve order of children, iterate in the ordered dict
-                parent.children = OrderedDict(
-                    (
-                        (k if k != old_name else name, v)
-                        for k, v in parent.children.items()
-                    )
-                )
+        parent = self._parent
+        if parent is not None:
+            old_name = self._name
+            if old_name is None:
+                raise ValueError("An unnamed node should not have had a parent")
+
+            # Iterate through the ordered dict to preserve the order of children
+            parent.children = OrderedDict(
+                ((k if k != old_name else name, v) for k, v in parent.children.items())
+            )
 
         self._name = name
 

--- a/datatree/treenode.py
+++ b/datatree/treenode.py
@@ -601,10 +601,22 @@ class NamedNode(TreeNode, Generic[Tree]):
                 raise TypeError("node name must be a string or None")
             if "/" in name:
                 raise ValueError("node names cannot contain forward slashes")
-        parent = self._parent
-        self.orphan()
+
+            parent = self._parent
+            if parent is not None:
+                old_name = self._name
+                if old_name is None:
+                    raise ValueError("An unnamed node should not have had a parent")
+
+                # To preserve order of children, iterate in the ordered dict
+                parent.children = OrderedDict(
+                    (
+                        (k if k != old_name else name, v)
+                        for k, v in parent.children.items()
+                    )
+                )
+
         self._name = name
-        self._set_parent(parent, name)
 
     def __str__(self) -> str:
         return f"NamedNode({self.name})" if self.name else "NamedNode()"

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -45,6 +45,10 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+
+- Renaming a node also update the key of its parent's children
+  (:issue:`309`)
+  By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Keep attributes on nodes containing no data in :py:func:`map_over_subtree`. (:issue:`278`, :pull:`279`)
   By `Sam Levang <https://github.com/slevang>`_.
 

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -46,7 +46,7 @@ Deprecations
 Bug fixes
 ~~~~~~~~~
 
-- Renaming a node also update the key of its parent's children
+- Renaming a node also updates the key of its parent's children
   (:issue:`309`, :pull:`310`)
   By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Keep attributes on nodes containing no data in :py:func:`map_over_subtree`. (:issue:`278`, :pull:`279`)

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -47,7 +47,7 @@ Bug fixes
 ~~~~~~~~~
 
 - Renaming a node also update the key of its parent's children
-  (:issue:`309`)
+  (:issue:`309`, :pull:`310`)
   By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Keep attributes on nodes containing no data in :py:func:`map_over_subtree`. (:issue:`278`, :pull:`279`)
   By `Sam Levang <https://github.com/slevang>`_.


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Small bugfix. I added a test reproducing the example in #309, and tests are not broken

Note: In `_post_attach`, I set the private `_name` instead of setting the `name`. Indeed, it can lead to infinite recursions when a setter is used inside of a class. I assume the `_post_attach` method is like a "runtime assertion"

- [x] Closes #309
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] ~~New functions/methods are listed in `api.rst`~~
- [x] Changes are summarized in `docs/source/whats-new.rst`
