### PR TITLE
Make illegal path-like variable names when constructing a DataTree from a Dataset

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -103,6 +103,18 @@ def _check_for_name_collisions(
         )
 
 
+def _check_for_slashes_in_names(variables: Iterable[Hashable]) -> None:
+    offending_variable_names = [
+        name for name in variables if isinstance(name, str) and "/" in name
+    ]
+    if len(offending_variable_names) > 0:
+        raise KeyError(
+            f"Given Dataset contains path-like variable names: {offending_variable_names}. "
+            "A Dataset represents a group, and a single group "
+            "cannot have path-like variable names. "
+        )
+
+
 class DatasetView(Dataset):
     """
     An immutable Dataset-like view onto the data in a single DataTree node.
@@ -401,6 +413,7 @@ class DataTree(
             children = {}
         ds = _coerce_to_dataset(data)
         _check_for_name_collisions(children, ds.variables)
+        _check_for_slashes_in_names(ds.variables)
 
         super().__init__(name=name)
 

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -1,3 +1,4 @@
+import re
 from copy import copy, deepcopy
 
 import numpy as np
@@ -67,6 +68,23 @@ class TestNames:
         sue = DataTree()
         mary = DataTree(children={"Sue": sue})  # noqa
         assert sue.name == "Sue"
+
+    def test_dataset_containing_slashes(self):
+        xda = xr.DataArray(
+            [[1, 2]],
+            coords={"label": ["a"], "R30m/y": [30, 60]},
+        )
+        xds = xr.Dataset({"group/subgroup/my_variable": xda})
+        with pytest.raises(
+            KeyError,
+            match=re.escape(
+                "Given Dataset contains path-like variable names: "
+                "['R30m/y', 'group/subgroup/my_variable']. "
+                "A Dataset represents a group, and a single group cannot "
+                "have path-like variable names. "
+            ),
+        ):
+            DataTree(xds)
 
 
 class TestPaths:

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -45,6 +45,10 @@ Deprecations
 
 Bug fixes
 ~~~~~~~~~
+
+- Make illegal path-like variable names when constructing a DataTree from a Dataset
+  (:issue:`311`, :pull:`314`)
+  By `Etienne Schalk <https://github.com/etienneschalk>`_.
 - Keep attributes on nodes containing no data in :py:func:`map_over_subtree`. (:issue:`278`, :pull:`279`)
   By `Sam Levang <https://github.com/slevang>`_.
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] Closes #311
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
~~- [ ] New functions/methods are listed in `api.rst`~~
- [ ] Changes are summarized in `docs/source/whats-new.rst`


## Technical Note

### Regarding `Hashable` vs `str` Dataset keys 

Note: DataTree keys are `Hashable`. I only check for slashes in the variable names if they are instance of `str`. 
I never encountered a case (yet) where a Dataset keys are not `str` but `Hashable` in the broader case. 
We can imagine corner-cases where keys would be other types of `Hashable`, eg `Path` from `pathlib`

```python
In [2]: from pathlib import Path

In [3]: hash(Path("/"))
Out[3]: -3809984204556177651
```

The choice I made is (1): only apply the check of slashes in the key if the key is an instance of `str`.
Another choice  (2)would be to project the `Hashable` space onto `str` space: `str(variable_name)` 
(1) seems more conservative than (2) as I do not pretend to be able to get a string representation for any `Hashable`.
