### PR TITLE
Allow opening selected groups only

### DIFF
--- a/datatree/tests/test_io.py
+++ b/datatree/tests/test_io.py
@@ -1,6 +1,7 @@
 import pytest
 import zarr.errors
 
+from datatree.datatree import DataTree
 from datatree.io import open_datatree
 from datatree.testing import assert_equal
 from datatree.tests import requires_h5netcdf, requires_netCDF4, requires_zarr
@@ -39,6 +40,19 @@ class TestIO:
         with pytest.raises(ValueError, match="unexpected encoding group.*"):
             original_dt.to_netcdf(filepath, encoding=enc, engine="netcdf4")
 
+    @requires_netCDF4
+    def test_to_netcdf_selected_groups(self, tmpdir, simple_datatree):
+        filepath = str(
+            tmpdir / "test.nc"
+        )  # casting to str avoids a pathlib bug in xarray
+        original_dt = simple_datatree
+        original_dt.to_netcdf(filepath, engine="netcdf4")
+
+        roundtrip_dt = open_datatree(filepath, groups=["set1"])
+        assert {
+            k for k in roundtrip_dt.keys() if isinstance(roundtrip_dt[k], DataTree)
+        } == {"set1"}
+
     @requires_h5netcdf
     def test_to_h5netcdf(self, tmpdir, simple_datatree):
         filepath = str(
@@ -50,6 +64,19 @@ class TestIO:
         roundtrip_dt = open_datatree(filepath)
         assert_equal(original_dt, roundtrip_dt)
 
+    @requires_h5netcdf
+    def test_to_h5netcdf_selected_groups(self, tmpdir, simple_datatree):
+        filepath = str(
+            tmpdir / "test.nc"
+        )  # casting to str avoids a pathlib bug in xarray
+        original_dt = simple_datatree
+        original_dt.to_netcdf(filepath, engine="h5netcdf")
+
+        roundtrip_dt = open_datatree(filepath, groups=["set1"])
+        assert {
+            k for k in roundtrip_dt.keys() if isinstance(roundtrip_dt[k], DataTree)
+        } == {"set1"}
+
     @requires_zarr
     def test_to_zarr(self, tmpdir, simple_datatree):
         filepath = str(
@@ -60,6 +87,19 @@ class TestIO:
 
         roundtrip_dt = open_datatree(filepath, engine="zarr")
         assert_equal(original_dt, roundtrip_dt)
+
+    @requires_zarr
+    def test_to_zarr_selected_groups(self, tmpdir, simple_datatree):
+        filepath = str(
+            tmpdir / "test.zarr"
+        )  # casting to str avoids a pathlib bug in xarray
+        original_dt = simple_datatree
+        original_dt.to_zarr(filepath)
+
+        roundtrip_dt = open_datatree(filepath, engine="zarr", groups=["set1"])
+        assert {
+            k for k in roundtrip_dt.keys() if isinstance(roundtrip_dt[k], DataTree)
+        } == {"set1"}
 
     @requires_zarr
     def test_zarr_encoding(self, tmpdir, simple_datatree):

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -23,6 +23,9 @@ v0.0.14 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Allow opening datatrees from file for just some selected groups (:pull:`338`)
+  By `Martin Raspaud <https://github.com/mraspaud>` and `Pouria Khalaj <https://github.com/pkhalaj>`
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This PR allows opening selected groups only in `open_datatree`.

The use case is speeding up loading of files with many groups, in our case netcdf, where we actually need a handful of groups to be loaded.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] Changes are summarized in `docs/source/whats-new.rst`
