### PR TITLE
Add match_names function to filter specific names

### DIFF
--- a/datatree/datatree.py
+++ b/datatree/datatree.py
@@ -1307,6 +1307,52 @@ class DataTree(
         }
         return DataTree.from_dict(matching_nodes, name=self.root.name)
 
+    def match_names(self, names: Iterable[str]) -> DataTree:
+        """
+        Filter nodes by name.
+
+        Parameters
+        ----------
+        names: Iterable[str]
+            The list of node names to retain.
+
+        Returns
+        -------
+        DataTree
+
+        See Also
+        --------
+        match
+        filter
+        pipe
+        map_over_subtree
+
+        Examples
+        --------
+        >>> dt = DataTree.from_dict(
+        ...     {
+        ...         "/a/A": None,
+        ...         "/a/B": None,
+        ...         "/a/C": None,
+        ...         "/C/D": None,
+        ...         "/E/F": None,
+        ...     }
+        ... )
+        >>> dt.match_names(["A", "C"])
+        DataTree('None', parent=None)
+        ├── DataTree('a')
+        │   └── DataTree('A')
+        │   └── DataTree('C')
+        └── DataTree('C')
+        """
+        names = set(names)
+        matching_nodes = {
+            node.path: node.ds
+            for node in self.subtree
+            if node.name in names
+        }
+        return DataTree.from_dict(matching_nodes, name=self.root.name)
+
     def map_over_subtree(
         self,
         func: Callable,

--- a/datatree/tests/test_datatree.py
+++ b/datatree/tests/test_datatree.py
@@ -707,6 +707,27 @@ class TestSubset:
         )
         dtt.assert_identical(result, expected)
 
+    def test_match_names(self):
+        # TODO is this example going to cause problems with case sensitivity?
+        dt = DataTree.from_dict(
+            {
+                "/a/A": None,
+                "/a/B": None,
+                "/a/C": None,
+                "/C/D": None,
+                "/E/F": None,
+            }
+        )
+        result = dt.match_names(["A", "C"])
+        expected = DataTree.from_dict(
+            {
+                "/a/A": None,
+                "/a/C": None,
+                "/C": None,
+            }
+        )
+        dtt.assert_identical(result, expected)
+
     def test_filter(self):
         simpsons = DataTree.from_dict(
             d={

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -103,6 +103,7 @@ For manipulating, traversing, navigating, or mapping over the tree structure.
    map_over_subtree
    DataTree.pipe
    DataTree.match
+   DataTree.match_names
    DataTree.filter
 
 Pathlib-like Interface

--- a/docs/source/whats-new.rst
+++ b/docs/source/whats-new.rst
@@ -23,6 +23,8 @@ v0.0.14 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- Added `DataTree.match_names` method to filter a list of specific node names.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

I came up with another method name that the one proposed in the issue, but I am happy to change that if `subset_nodes` sounds better.

- [x] Closes #232 
- [x] Tests added
- [ ] Passes `pre-commit run --all-files`
- [x] New functions/methods are listed in `api.rst`
- [x] Changes are summarized in `docs/source/whats-new.rst`
